### PR TITLE
Improve spec file logic

### DIFF
--- a/packaging/templates/infrastructure-formulas.spec.j2
+++ b/packaging/templates/infrastructure-formulas.spec.j2
@@ -20,7 +20,7 @@
 %define sdir %{fdir}/states
 %define mdir %{fdir}/metadata
 Name:           infrastructure-formulas
-Version:        0.2
+Version:        0
 Release:        0
 Summary:        Custom Salt states for the openSUSE/SUSE infrastructures
 License:        GPL-3.0-or-later
@@ -62,12 +62,16 @@ mv %{_sourcedir}/salt-formulas-%{version}/* .
 %install
 install -dm0755 %{buildroot}%{sdir} %{buildroot}%{mdir}
 
-for formula in $(find -mindepth 1 -maxdepth 1 -type d -not -path './.git' -printf '%%P\n')
+for formula in $(find -mindepth 1 -maxdepth 1 -type d -name '*-formula' -printf '%%P\n')
 do
   echo "$formula"
   fname="${formula%%-*}"
 
   src_states="$formula/$fname"
+  if [ ! -d "$src_states" ]
+  then
+    src_states="$formula/${fname//_/-}"
+  fi
   src_metadata="$formula/metadata"
 
   dst_states="%{sdir}/$fname"


### PR DESCRIPTION
Results from releasing version 0.4, it can only go better with 0.5. :-)

- set version to 0, it is automatically updated by the set_version service
- run loop only for directories ending in "-formula" (it tried to package the "packaging" directory ...)
- add conditional to replace "_" with "-" in the states directory reference - this is a bit ugly - I should decide on either hyphens or underscores and not mix both