### PR TITLE
zypper: combine packages

### DIFF
--- a/zypper-formula/zypper/packages.sls
+++ b/zypper-formula/zypper/packages.sls
@@ -1,13 +1,45 @@
-{% set packages = salt['pillar.get']('zypper:packages', {}) %}
+{%- set packages = salt['pillar.get']('zypper:packages', {}) %}
+{%- set defaults = namespace(refresh=False) %}
+{%- set fromdefaults = [] %}
+{%- set fromrepos = {} %}
 
-{% for package, data in packages.items() %}
+{%- for package, config in packages.items() %}
+
+{%- if 'fromrepo' in config -%}
+{%- set refresh = config.get('refresh', False) -%}
+{%- do fromrepos.update({ package: {'fromrepo': config.fromrepo, 'refresh': refresh} }) %}
+{%- else %}
+
+{%- if 'refresh' in config and config.refresh -%}
+{%- set defaults.refresh = True -%}
+{%- endif %}
+{%- do fromdefaults.append(package) %}
+{%- endif %}
+
+{%- endfor %}
+
+{%- if fromdefaults | length %}
+zypper_packages:
+  pkg.installed:
+    - pkgs:
+      {%- for package in fromdefaults %}
+      - {{ package }}
+      {%- endfor %}
+    {%- if defaults.refresh %}
+    - refresh: True
+    {%- endif %}
+{%- endif %}
+
+{%- if fromrepos | length %}
+{%- for package, data in fromrepos.items() %}
 zypper_pkg_{{ package }}:
   pkg.installed:
     - name: {{ package }}
-    {% if 'refresh' in data %}
+    {%- if 'refresh' in data %}
     - refresh: {{ data.refresh }}
-    {% endif %}
-    {% if 'fromrepo' in data %}
+    {%- endif %}
+    {%- if 'fromrepo' in data %}
     - fromrepo: {{ data.fromrepo }}
-    {% endif %}
-{% endfor %}
+    {%- endif %}
+{%- endfor %}
+{%- endif %}


### PR DESCRIPTION
Combine packages without a "fromrepo" setting in a single pkg.installed call.

Example pillar:

```
zypper:
  packages:
    susepaste: {}
    emacs: {}
    lsof:
      fromrepo: SUSEInfra:Tools
      refresh: True
    wget:
      refresh: True
    infrastructure-formulas:
      fromrepo: SUSEInfra:Tools
```

Rendered state:

```
    zypper_packages:
      pkg.installed:
        - pkgs:
          - susepaste
          - emacs
          - wget
        - refresh: True
    zypper_pkg_lsof:
      pkg.installed:
        - name: lsof
        - refresh: True
        - fromrepo: SUSEInfra:Tools
    zypper_pkg_infrastructure-formulas:
      pkg.installed:
        - name: infrastructure-formulas
        - refresh: False
        - fromrepo: SUSEInfra:Tools
```

All packages _without_ `fromrepo` are combined to one. If any one of the packages _without_ `fromrepo` have `refresh` set to `True`, `refresh: True` will be set on the complete combined state - this makes sense, as no individual `--refresh` arguments are passed by `modules.zypperpkg` anyways - it runs one refresh before the installation call.
All packages _with_ `fromrepo` are kept in the traditional single package approach.  A cherry on top would be to map together the ones with matching `fromrepo` options, however we don't use this often, if at all.