### PR TITLE
Refactor fencing + implement SBD

### DIFF
--- a/suse_ha-formula/pillar.example
+++ b/suse_ha-formula/pillar.example
@@ -6,8 +6,53 @@ mine_functions:
 
 suse_ha:
   fencing:
-    # enabled by default, needs additional configuration
+    # enabled by default
     enable: false
+    # disabled by default - only works together with 'enable: true' and with a minimum of two nodes
+    stonith_enable: false
+    #
+    # currently, the formula supports the configuration of IPMI and SBD fencing using the agents from cluster-glue
+    #
+    # if 'ipmi' is specified, it will be configured - omit the block to not configure IPMI
+    ipmi:
+      # optional attribute overrides to use for the IPMI resources
+      # by default, the values from suse_ha/defaults/fencing/external_ipmi.yaml will be used
+      primitive:
+        operations:
+          start:
+            timeout: 30
+      # IPMI resources to configure
+      hosts:
+        # any amount of IPMI resources can be configured
+        # all dictionary keys are mandatory
+        dev-ipmi0:
+          ip: 192.168.120.1
+          user: admin
+          interface: lanplus
+          priv: ADMINISTRATOR
+          # it is recommended to encrypt any IPMI credentials using PGP
+          # the formula will store the passphrase in a separate file instead of directly in the CIB
+          secret: password
+    # if 'sbd' is specified, it will be configured - omit the block to not configure SBD
+    sbd:
+      # SBD resources to configure
+      instances:
+        minion0:
+          # currently pcmk_host_list, pcmk_delay_base and pcmk_delay_max can be configured
+          # these are optional and do not have default values set by the formula
+          pcmk_host_list: minion0
+          pcmk_delay_base: 0
+        # use an empty dictionary to not configure any attributes
+        minion1: {}
+        dynamic:
+          pcmk_delay_max: 5
+      # block devices to use for SBD
+      devices:
+        # it is recommended to use unique identifiers as the formula will overwrite any devices without SBD metadata
+        # whilst the formula does not limit the amount of devices, the cluster stack might - SBD suggests the use of 1-3 devices
+        - /dev/sda
+        - /dev/sdb
+
   cluster:
     # the name of the cluster needs to be a string all node hostnames start with
     # for example, if the cluster nodes are named "pizza1", "pizza2" and "pizza3", then the cluster name must be "pizza"
@@ -17,6 +62,7 @@ suse_ha:
     ip_version: ipv4
     # native Corosync only requires the nodeid for IPv6 based operation - this formula always requires it
     nodeid: 1
+
   multicast:
     # configure the bind address in a node-specific pillar and have it merged
     bind_address: '192.168.121.55'
@@ -25,6 +71,7 @@ suse_ha:
   # it is highly recommended to additionally encrypt the base64 string using PGP, in which case the file header needs to be #!gpg|yaml for the binary to stay intact
   cluster_secret: !!binary |
     LGljyn1fBRRcxLxFEgOmhILNTFY/13Cn3EwqqaBN6ynrX6flhiGyTjfW8eAQ1zlJex3uO9kssIcANw9uXLLpOCJ/Fvia3yzHNzCIxfW0zayUOBSMypN1TMKjad5/n8frAFZWNBhTcbk1Cwi764yBj8ErhsPh264qEreRzznJFGI=
+
   # cluster resources
   resources:
     # name of the primitive resource

--- a/suse_ha-formula/suse_ha/defaults.yaml
+++ b/suse_ha-formula/suse_ha/defaults.yaml
@@ -6,20 +6,6 @@ cluster:
   ip_version: ipv6
 fencing:
   enable: true
-  ipmi:
-    primitive:
-      operations:
-        start:
-          timeout: 20
-          interval: 0
-        stop:
-          timeout: 15
-          interval: 0
-        monitor:
-          timeout: 20
-          interval: 3600
-      meta_attributes:
-        target-role: Started
 sysconfig:
   pacemaker:
     LRMD_MAX_CHILDREN: 4

--- a/suse_ha-formula/suse_ha/defaults/fencing/external_ipmi.yaml
+++ b/suse_ha-formula/suse_ha/defaults/fencing/external_ipmi.yaml
@@ -1,0 +1,15 @@
+---
+ipmi:
+  primitive:
+    operations:
+      start:
+        timeout: 20
+        interval: 0
+      stop:
+        timeout: 15
+        interval: 0
+      monitor:
+        timeout: 20
+        interval: 3600
+    meta_attributes:
+      target-role: Started

--- a/suse_ha-formula/suse_ha/defaults/fencing/external_sbd.yaml
+++ b/suse_ha-formula/suse_ha/defaults/fencing/external_sbd.yaml
@@ -1,0 +1,13 @@
+---
+sbd:
+  primitive:
+    operations:
+      start:
+        timeout: 20
+        interval: 0
+      stop:
+        timeout: 15
+        interval: 0
+      monitor:
+        timeout: 20
+        interval: 3600

--- a/suse_ha-formula/suse_ha/macros.jinja
+++ b/suse_ha-formula/suse_ha/macros.jinja
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -#}
 
 {%- from './map.jinja' import resources_dir, management -%}
-{%- macro ha_resource(resource, class, type, instance_attributes, operations, meta_attributes={}, provider='NONE', clone={}) %}
+{%- macro ha_resource(resource, class, type, instance_attributes, operations, meta_attributes={}, provider='NONE', clone={}, requires=[]) %}
 ha_resource_file_{{ resource }}:
   file.managed:
     - name: {{ resources_dir }}/{{ resource }}.xml
@@ -44,6 +44,9 @@ ha_resource_file_{{ resource }}:
             provider: {{ provider }}
     - require:
       - file: ha_resources_directory
+      {%- for require in requires %}
+      - {{ require }}
+      {%- endfor %}
 
 ha_resource_update_{{ resource }}:
   cmd.run:

--- a/suse_ha-formula/suse_ha/macros.jinja
+++ b/suse_ha-formula/suse_ha/macros.jinja
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ha_resource_file_{{ resource }}:
   file.managed:
     - name: {{ resources_dir }}/{{ resource }}.xml
-    - source: salt://{{ slspath }}/files/cib/{{ 'clone' if clone else 'resource' }}.xml.j2
+    - source: salt://suse_ha/files/cib/{{ 'clone' if clone else 'resource' }}.xml.j2
     - template: jinja
     - context:
         {%- if clone %}

--- a/suse_ha-formula/suse_ha/macros.jinja
+++ b/suse_ha-formula/suse_ha/macros.jinja
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -#}
 
 {%- from './map.jinja' import resources_dir, management -%}
-{%- macro ha_resource(resource, class, type, instance_attributes, operations, meta_attributes, provider='NONE', clone={}) %}
+{%- macro ha_resource(resource, class, type, instance_attributes, operations, meta_attributes={}, provider='NONE', clone={}) %}
 ha_resource_file_{{ resource }}:
   file.managed:
     - name: {{ resources_dir }}/{{ resource }}.xml

--- a/suse_ha-formula/suse_ha/map.jinja
+++ b/suse_ha-formula/suse_ha/map.jinja
@@ -50,3 +50,22 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- endif -%}
 
 {%- set sbd = fencing.get('sbd', {}) -%}
+
+{%- set host = grains['host'] -%}
+{%- set id = grains['id'] -%}
+
+{%- set nodes = salt['mine.get'](cluster.name ~ '*', 'network.get_hostname') | sort -%}
+{%- if nodes | length -%}
+{%- set primary = nodes[0] -%}
+{%- do salt.log.debug('suse_ha: elected primary node is ' ~ primary) -%}
+{%- else -%}
+{%- do salt.log.error('suse_ha: no nodes found in cluster') -%}
+{%- set primary = None -%}
+{%- endif -%}
+
+{%- if host == primary or id == primary -%}
+{%- set is_primary = True -%}
+{%- else -%}
+{%- set is_primary = False -%}
+{%- endif -%}
+{%- do salt.log.debug('suse_ha: is_primary: ' ~ is_primary) -%}

--- a/suse_ha-formula/suse_ha/map.jinja
+++ b/suse_ha-formula/suse_ha/map.jinja
@@ -32,7 +32,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- set resources = hapillar.get('resources', {}) -%}
 {%- set sysconfig = hapillar.get('sysconfig', {}) -%}
 
-{%- set fence_agents = ['external_ipmi'] -%}
+{%- set fence_agents = ['external_ipmi', 'external_sbd'] -%}
 {%- set fence_ns = namespace(construct=false) -%}
 
 {%- for agent in fence_agents -%}

--- a/suse_ha-formula/suse_ha/map.jinja
+++ b/suse_ha-formula/suse_ha/map.jinja
@@ -32,9 +32,18 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- set resources = hapillar.get('resources', {}) -%}
 {%- set sysconfig = hapillar.get('sysconfig', {}) -%}
 
-{%- if 'ipmi' in fencing_base -%}
-{%- import_yaml './defaults/fencing/external_ipmi.yaml' as fencing_external_ipmi -%}
-{%- do fencing_base.update(fencing_external_ipmi) -%}
+{%- set fence_agents = ['external_ipmi'] -%}
+{%- set fence_ns = namespace(construct=false) -%}
+
+{%- for agent in fence_agents -%}
+{%- if agent.replace('external_', '') in fencing_base -%}
+{%- import_yaml './defaults/fencing/' ~ agent ~ '.yaml' as fencing_defaults -%}
+{%- do fencing_base.update(fencing_defaults) -%}
+{%- set fence_ns.construct = true -%}
+{%- endif -%}
+{%- endfor -%}
+
+{%- if fence_ns.construct -%}
 {%- set fencing = salt.pillar.get('suse_ha:fencing', default=fencing_base, merge=True) -%}
 {%- else -%}
 {%- set fencing = fencing_base -%}

--- a/suse_ha-formula/suse_ha/map.jinja
+++ b/suse_ha-formula/suse_ha/map.jinja
@@ -28,6 +28,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- set multicast = {} -%}
 {%- do salt.log.error('suse_ha: No multicast pillar provided - configuration might be incomplete!') -%}
 {%- endif -%}
-{%- set fencing = hapillar.get('fencing', {}) -%}
+{%- set fencing_base = hapillar.get('fencing', {}) -%}
 {%- set resources = hapillar.get('resources', {}) -%}
 {%- set sysconfig = hapillar.get('sysconfig', {}) -%}
+
+{%- if 'ipmi' in fencing_base -%}
+{%- import_yaml './defaults/fencing/external_ipmi.yaml' as fencing_external_ipmi -%}
+{%- do fencing_base.update(fencing_external_ipmi) -%}
+{%- set fencing = salt.pillar.get('suse_ha:fencing', default=fencing_base, merge=True) -%}
+{%- else -%}
+{%- set fencing = fencing_base -%}
+{%- endif -%}

--- a/suse_ha-formula/suse_ha/map.jinja
+++ b/suse_ha-formula/suse_ha/map.jinja
@@ -48,3 +48,5 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- else -%}
 {%- set fencing = fencing_base -%}
 {%- endif -%}
+
+{%- set sbd = fencing.get('sbd', {}) -%}

--- a/suse_ha-formula/suse_ha/pacemaker/fencing/external_ipmi.sls
+++ b/suse_ha-formula/suse_ha/pacemaker/fencing/external_ipmi.sls
@@ -27,7 +27,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       'hostname': host, 'ipaddr': config['ip'], 'passwd': '/etc/pacemaker/ha_ipmi_' ~ host, 'userid': config['user'],
       'interface': config['interface'], 'passwd_method': 'file', 'ipmitool': '/usr/bin/ipmitool', 'priv': config['priv'] } %}
 
-{#- at the time of writing, this requires a custom patch: https://github.com/ClusterLabs/cluster-glue/pull/39 #}
 {%- if 'port' in config %}
 {%- do instance_attributes.update({'ipport': config['port']}) -%}
 {%- endif %}

--- a/suse_ha-formula/suse_ha/pacemaker/fencing/external_ipmi.sls
+++ b/suse_ha-formula/suse_ha/pacemaker/fencing/external_ipmi.sls
@@ -1,0 +1,43 @@
+{#-
+Salt state file for managing IPMI fencing resources
+Copyright (C) 2023 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-#}
+
+{%- from slspath ~ '/../../map.jinja' import fencing, ha_resource, ipmi_secret -%}
+{%- from slspath ~ '/../../macros.jinja' import ha_resource, ipmi_secret -%}
+{%- set fencing_ipmi = fencing.get('ipmi', {}) -%}
+
+{%- if 'hosts' in fencing_ipmi %}
+{%- for host, config in fencing_ipmi.hosts.items() %}
+
+{%- set instance_attributes = {
+      'hostname': host, 'ipaddr': config['ip'], 'passwd': '/etc/pacemaker/ha_ipmi_' ~ host, 'userid': config['user'],
+      'interface': config['interface'], 'passwd_method': 'file', 'ipmitool': '/usr/bin/ipmitool', 'priv': config['priv'] } %}
+
+{#- at the time of writing, this requires a custom patch: https://github.com/ClusterLabs/cluster-glue/pull/39 #}
+{%- if 'port' in config %}
+{%- do instance_attributes.update({'ipport': config['port']}) -%}
+{%- endif %}
+
+{{ ha_resource(host, class='stonith', type='external/ipmi', instance_attributes=instance_attributes,
+                      operations=fencing.ipmi.primitive.operations, meta_attributes=fencing.ipmi.primitive.meta_attributes) }}
+
+{{ ipmi_secret(host, config['secret'], True) }}
+
+{%- endfor %}
+{%- else %}
+{%- do salt.log.error('suse_ha: pacemaker.fencing.external_ipmi called, but no hosts defined in pillar') -%}
+{%- endif %}

--- a/suse_ha-formula/suse_ha/pacemaker/fencing/external_sbd.sls
+++ b/suse_ha-formula/suse_ha/pacemaker/fencing/external_sbd.sls
@@ -1,0 +1,42 @@
+{#-
+Salt state file for managing SBD fencing resources
+Copyright (C) 2023 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-#}
+
+{%- from slspath ~ '/../../map.jinja' import fencing, ha_resource, ipmi_secret -%}
+{%- from slspath ~ '/../../macros.jinja' import ha_resource -%}
+{%- set fencing_sbd = fencing.get('sbd', {}) -%}
+{%- set instance_defaults = fencing_sbd.get('defaults', {}) -%}
+{%- set attributes = ['pcmk_host_list', 'pcmk_delay_base', 'pcmk_delay_max'] %}
+
+{%- if 'instances' in fencing_sbd %}
+{%- for instance, config in fencing_sbd.instances.items() %}
+{%- set instance_attributes = {} -%}
+
+{%- for attribute in attributes %}
+{%- if attribute in config %}
+{%- do instance_attributes.update({attribute: config[attribute]}) -%}
+{%- elif attribute in instance_defaults -%}
+{%- do instance_attributes.update({attribute: instance_defaults[attribute]}) -%}
+{%- endif %}
+{%- endfor %}
+
+{{ ha_resource('sbd-' ~ instance, class='stonith', type='external/sbd', instance_attributes=instance_attributes, operations=fencing.sbd.primitive.operations) }}
+
+{%- endfor %}
+{%- else %}
+{%- do salt.log.error('suse_ha: pacemaker.fencing.external_sbd called, but no instances defined in pillar') -%}
+{%- endif %}

--- a/suse_ha-formula/suse_ha/pacemaker/fencing/external_sbd.sls
+++ b/suse_ha-formula/suse_ha/pacemaker/fencing/external_sbd.sls
@@ -22,6 +22,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- set instance_defaults = fencing_sbd.get('defaults', {}) -%}
 {%- set attributes = ['pcmk_host_list', 'pcmk_delay_base', 'pcmk_delay_max'] %}
 
+include:
+  - suse_ha.sbd
+
 {%- if 'instances' in fencing_sbd %}
 {%- for instance, config in fencing_sbd.instances.items() %}
 {%- set instance_attributes = {} -%}
@@ -34,7 +37,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- endif %}
 {%- endfor %}
 
-{{ ha_resource('sbd-' ~ instance, class='stonith', type='external/sbd', instance_attributes=instance_attributes, operations=fencing.sbd.primitive.operations) }}
+{{ ha_resource('sbd-' ~ instance, class='stonith', type='external/sbd', instance_attributes=instance_attributes, operations=fencing.sbd.primitive.operations, requires=['service: sbd_service']) }}
 
 {%- endfor %}
 {%- else %}

--- a/suse_ha-formula/suse_ha/pacemaker/init.sls
+++ b/suse_ha-formula/suse_ha/pacemaker/init.sls
@@ -122,6 +122,9 @@ pacemaker.service:
     - name: /etc/sysconfig/pacemaker
     - separator: '='
     - show_changes: True
+    {%- if opts['test'] %}
+    - ignore_if_missing: True
+    {%- endif %}
     - key_values:
         {%- for key, value in sysconfig.pacemaker.items() %}
         '{{ key }}': '"{{ value }}"'

--- a/suse_ha-formula/suse_ha/pacemaker/init.sls
+++ b/suse_ha-formula/suse_ha/pacemaker/init.sls
@@ -82,8 +82,13 @@ ha_add_admin_ip:
 
 include:
   - suse_ha.packages
-{%- if fencing.enable and 'ipmi' in fencing %}
+{%- if fencing.enable %}
+{%- if 'ipmi' in fencing %}
   - .fencing.external_ipmi
+{%- endif %}
+{%- if 'sbd' in fencing %}
+  - .fencing.external_sbd
+{%- endif %}
 {%- endif %}
   - suse_ha.resources
 

--- a/suse_ha-formula/suse_ha/pacemaker/init.sls
+++ b/suse_ha-formula/suse_ha/pacemaker/init.sls
@@ -108,6 +108,10 @@ pacemaker.service:
   service.running:
     - enable: True
     - reload: True
+    - retry:
+        attempts: 3
+        interval: 10
+        splay: 5
     - require:
       - suse_ha_packages
       - corosync.service

--- a/suse_ha-formula/suse_ha/pacemaker/init.sls
+++ b/suse_ha-formula/suse_ha/pacemaker/init.sls
@@ -16,8 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -#}
 
-{%- from slspath ~ '/../map.jinja' import cluster, fencing, management, sysconfig -%}
-{%- from slspath ~ '/../macros.jinja' import ha_resource, property, rsc_default, ipmi_secret -%}
+{%- from 'suse_ha/map.jinja' import cluster, fencing, management, sysconfig -%}
+{%- from 'suse_ha/macros.jinja' import ha_resource, property, rsc_default, ipmi_secret -%}
 {%- set myfqdn = grains['fqdn'] -%}
 {%- set myhost = grains['host'] -%}
 {%- if salt['cmd.retcode']('test -x /usr/sbin/crmadmin') == 0 -%}

--- a/suse_ha-formula/suse_ha/pacemaker/init.sls
+++ b/suse_ha-formula/suse_ha/pacemaker/init.sls
@@ -32,7 +32,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {{ property('default-resource-stickiness', 1000) }}
 #}
 
-{%- if fencing.enable and fencing.get('stonith_enabled', False)
+{%- if fencing.enable and fencing.get('stonith_enable', False)
   and (salt['mine.get'](cluster.name ~ '*', 'network.get_hostname', tgt_type='compound') | length()) >= 2 %}
 {{ property('stonith-enabled', 'true') }}
 {% else %}

--- a/suse_ha-formula/suse_ha/packages.sls
+++ b/suse_ha-formula/suse_ha/packages.sls
@@ -16,6 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -#}
 
+{%- from slspath ~ '/map.jinja' import fencing -%}
+
 suse_ha_packages:
   pkg.installed:
     - pkgs:
@@ -32,6 +34,6 @@ suse_ha_packages:
       {%- endif %}
       - resource-agents
       - virt-top
-
-# in case we need SBD in the future, we can include this with a conditional
-#- sbd
+      {%- if 'sbd' in fencing %}
+      - sbd
+      {%- endif %}

--- a/suse_ha-formula/suse_ha/sbd.sls
+++ b/suse_ha-formula/suse_ha/sbd.sls
@@ -1,0 +1,101 @@
+{#-
+Salt state file for managing SBD devices
+Copyright (C) 2023 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-#}
+
+{%- from slspath ~ '/map.jinja' import sbd, sysconfig -%}
+{%- if 'devices' in sbd %}
+include:
+  - .packages
+
+{%- set devices = sbd['devices'] %}
+{%- set cmd_base = 'sbd' -%}
+{%- set sbd_ns = namespace(deviceargs='', timeoutargs='', devices='') -%}
+
+{%- for device in devices -%}
+{%- set sbd_ns.deviceargs = sbd_ns.deviceargs ~ ' -d ' ~ device -%}
+{%- set sbd_ns.devices = sbd_ns.devices ~ device -%}
+{%- if not loop.last -%}
+{%- set sbd_ns.devices = sbd_ns.devices ~ ';' -%}
+{%- endif -%}
+{%- endfor -%} {#- close devices loop -#}
+
+{%- if 'timeouts' in sbd -%}
+{%- set timeout_msgwait = sbd.timeouts.get('msgwait', False) -%}
+{%- if timeout_msgwait -%}
+{%- set sbd_ns.timeoutargs = sbd_ns.timeoutargs ~ ' -4 ' ~ timeout_msgwait -%}
+{%- endif -%}
+{%- set timeout_watchdog = sbd.timeouts.get('watchdog', False) -%}
+{%- if timeout_watchdog -%}
+{%- set sbd_ns.timeoutargs = sbd_ns.timeoutargs ~ ' -1 ' ~ timeout_watchdog -%}
+{%- endif %}
+{%- endif %} {#- close timeouts check -#}
+
+{%- set cmd_base = cmd_base ~ ' ' ~ sbd_ns.deviceargs ~ ' ' -%}
+{%- set cmd_format = cmd_base ~ sbd_ns.timeoutargs ~ ' create' -%}
+{%- set cmd_check = cmd_base ~ ' dump' -%}
+
+{%- do salt.log.debug('suse_ha: constructed SBD cmd_format: ' ~ cmd_format) -%}
+{%- do salt.log.debug('suse_ha: constructed SBD cmd_check: ' ~ cmd_check) %}
+
+sbd_shutdown:
+  service.dead:
+    - name: corosync
+    - prereq:
+      - cmd: sbd_format_devices
+    - require:
+      - suse_ha_packages
+
+sbd_format_devices:
+  cmd.run:
+    - name: {{ cmd_format }}
+    {%- if not sbd.get('reconfigure', False) %}
+    - unless: {{ cmd_check }}
+    {%- endif %}
+    - require:
+      - suse_ha_packages
+
+sbd_sysconfig:
+  file.keyvalue:
+    - name: /etc/sysconfig/sbd
+    {%- if opts['test'] %}
+    - ignore_if_missing: True
+    {%- endif %}
+    - separator: '='
+    - show_changes: True
+    - uncomment: '#'
+    - key_values:
+        SBD_DEVICE: {{ sbd_ns.devices }}
+        {%- if sysconfig.get('sbd', False) %}
+        {%- for key, value in sysconfig.sbd.items() %}
+        '{{ key }}': '"{{ value }}"'
+        {%- endfor %}
+        {%- endif %}
+    - require:
+      - suse_ha_packages
+
+sbd_service:
+  service.enabled:
+    - name: sbd
+    - require:
+      - suse_ha_packages
+    - watch:
+      - cmd: sbd_format_devices
+      - file: sbd_sysconfig
+
+{%- else %}
+{%- do salt.log.error('suse_ha: sbd.devices called with no devices in the pillar') -%}
+{%- endif %} {#- close devices check -#}

--- a/suse_ha-formula/suse_ha/sbd.sls
+++ b/suse_ha-formula/suse_ha/sbd.sls
@@ -21,17 +21,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 include:
   - .packages
 
-{%- set devices = sbd['devices'] %}
+{%- set devices = sbd['devices'] -%}
 {%- set cmd_base = 'sbd' -%}
 {%- set sbd_ns = namespace(deviceargs='', timeoutargs='', devices='') -%}
 
 {%- for device in devices -%}
 {%- set sbd_ns.deviceargs = sbd_ns.deviceargs ~ ' -d ' ~ device -%}
-{%- set sbd_ns.devices = sbd_ns.devices ~ device -%}
-{%- if not loop.last -%}
-{%- set sbd_ns.devices = sbd_ns.devices ~ ';' -%}
-{%- endif -%}
-{%- endfor -%} {#- close devices loop -#}
+{%- endfor -%}
+{%- set sbd_ns.devices = devices | join(';') -%}
 
 {%- if 'timeouts' in sbd -%}
 {%- set timeout_msgwait = sbd.timeouts.get('msgwait', False) -%}
@@ -41,8 +38,8 @@ include:
 {%- set timeout_watchdog = sbd.timeouts.get('watchdog', False) -%}
 {%- if timeout_watchdog -%}
 {%- set sbd_ns.timeoutargs = sbd_ns.timeoutargs ~ ' -1 ' ~ timeout_watchdog -%}
-{%- endif %}
-{%- endif %} {#- close timeouts check -#}
+{%- endif -%}
+{%- endif -%} {#- close timeouts check -#}
 
 {%- set cmd_base = cmd_base ~ ' ' ~ sbd_ns.deviceargs ~ ' ' -%}
 {%- set cmd_format = cmd_base ~ sbd_ns.timeoutargs ~ ' create' -%}


### PR DESCRIPTION
**Refactor:**
- refactor defaults handling, split out fencing defaults to individual files and construct fencing configuration based on the agents configured in the `suse_ha:fencing` pillar
- move existing IPMI fencing logic to individual state file

**New:**
- add SBD fencing agent state and defaults map

**Change:**
- `suse_ha:fencing:stonith_enabled` is now `suse_ha:fencing:stonith_enable` for consistency with the other `enable` option

Solves: https://github.com/openSUSE/salt-formulas/issues/25