### PR TITLE
NetApp ONTAP formula

### DIFF
--- a/netapp_ontap-formula/_modules/ontap.py
+++ b/netapp_ontap-formula/_modules/ontap.py
@@ -133,7 +133,7 @@ def _result(result):
     log.warning('ontap_ansible: dumping unknown result')
     return result
 
-def get_lun(comment=None, uuid=None):
+def get_lun(comment=None, uuid=None, get_next_free=False):
     if (comment is not None) and (uuid is not None):
         log.error(f'Only a single filter may be specified')
         raise ValueError('Only a single filter may be specified')
@@ -155,6 +155,10 @@ def get_lun(comment=None, uuid=None):
     descend = ['response', 'records']
     varmap.update({'playbook': f'playbooks/{playbook}.yml', 'descend': descend})
 
+    if get_next_free and comment is None and uuid is None:
+        result = _call(**varmap, single_task=False)
+        next_free = result[5].get('ansible_facts', {}).get('lun_id')
+        return result[0], next_free
     result = _call(**varmap)
     return result
 

--- a/netapp_ontap-formula/_modules/ontap.py
+++ b/netapp_ontap-formula/_modules/ontap.py
@@ -1,0 +1,95 @@
+"""
+Salt execution module for maging ONTAP based NetApp storage systems using Ansible
+Copyright (C) 2023 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import logging
+
+log = logging.getLogger(__name__)
+
+# https://stackoverflow.com/a/9808122
+def _find(key, value):
+  for k, v in value.items():
+    if k == key:
+      yield v
+    elif isinstance(v, dict):
+      for result in find(key, v):
+        yield result
+    elif isinstance(v, list):
+      for d in v:
+        for result in find(key, d):
+          yield result
+
+def _config():
+    return __utils__['ontap_config.config']()
+
+def _call(host, certificate, key, rundir, playbook, extravars={}, descend=[]):
+    host, colon, port = host.rpartition(':')
+    varmap = {'ontap_host': host, 'ontap_port': int(port), 'ontap_crt': certificate, 'ontap_key': key}
+    if extravars:
+        varmap.update(extravars)
+    log.debug(f'ontap_ansible: executing {playbook} with {varmap} in {rundir}')
+    out = __salt__['ansible.playbooks'](
+            playbook=playbook, rundir=rundir, extra_vars=varmap)
+
+    plays = out.get('plays', [])
+    plays_len = len(plays)
+    if not plays_len:
+        log.error(f'ontap_ansible: returned with no plays')
+        return False
+    if plays_len > 0:
+        log.warning(f'ontap_ansible: discarding {plays_len} additional plays')
+    play0 = plays[0]
+
+    tasks = play0.get('tasks', [])
+    tasks_len = len(tasks)
+    if not tasks_len:
+        log.error(f'ontap_ansible: play returned with no tasks')
+        return False
+    if tasks_len > 0:
+        log.warning(f'ontap_ansible: discarding {tasks_len} additional tasks')
+    task0 = tasks[0]
+
+    task = task0.get('hosts').get('localhost')
+    if task is None:
+        log.error(f'ontap_ansible: unable to parse task - ensure it executed locally')
+        return False
+
+    if descend:
+        if isinstance(descend, str):
+            descend = [descend]
+        for level in descend:
+            gain = task.get(level)
+            if gain is None:
+                break
+            if gain is not None:
+                log.debug(f'ontap_ansible: found artifact for {level}')
+                task = gain
+
+    return task
+
+
+def get_lun(uuid=None):
+    varmap = _config()
+    if uuid:
+        varmap.update({'extravars': {'ontap_lun_uuid': uuid}})
+        playbook = 'fetch-lun_restit'
+    else:
+        playbook = 'fetch-luns_restit'
+    descend = ['response', 'records']
+    varmap.update({'playbook': f'playbooks/{playbook}.yml', 'descend': descend})
+    result = _call(**varmap)
+    return result

--- a/netapp_ontap-formula/_modules/ontap.py
+++ b/netapp_ontap-formula/_modules/ontap.py
@@ -82,14 +82,27 @@ def _call(host, certificate, key, rundir, playbook, extravars={}, descend=[]):
     return task
 
 
-def get_lun(uuid=None):
+def get_lun(comment=None, uuid=None):
+    if (comment is not None) and (uuid is not None):
+        log.error(f'Only a single filter may be specified')
+        raise ValueError('Only a single filter may be specified')
     varmap = _config()
-    if uuid:
-        varmap.update({'extravars': {'ontap_lun_uuid': uuid}})
+    extravars = None
+
+    if comment:
+        playbook = 'fetch-lun-by-comment_restit'
+        extravars = {'extravars': {'ontap_lun_comment': comment}}
+    elif uuid:
         playbook = 'fetch-lun_restit'
-    else:
+        extravars = {'extravars': {'ontap_lun_uuid': uuid}}
+
+    if extravars is None:
         playbook = 'fetch-luns_restit'
+    else:
+        varmap.update(extravars)
+
     descend = ['response', 'records']
     varmap.update({'playbook': f'playbooks/{playbook}.yml', 'descend': descend})
+
     result = _call(**varmap)
     return result

--- a/netapp_ontap-formula/_modules/ontap.py
+++ b/netapp_ontap-formula/_modules/ontap.py
@@ -183,6 +183,15 @@ def provision_lun(name, size, volume, vserver, comment=None):
     result = _call(**varmap)
     return _result(result)
 
+# to-do: support property updates other than size changes
+def update_lun(name, size, volume, vserver):
+    varmap = _config()
+    size = _parse_size(size)
+    path = _path(volume, name)
+    varmap.update({'playbook': 'playbooks/patch-lun_restit.yml', 'extravars': {'ontap_lun_path': path, 'ontap_vserver': vserver, 'ontap_size': size}})
+    result = _call(**varmap)
+    return _result(result)
+
 def _delete_lun(name=None, volume=None, uuid=None):
     if (name is None or volume is None) and (uuid is None):
         log.error('Specify either name and volume or uuid')

--- a/netapp_ontap-formula/_modules/ontap.py
+++ b/netapp_ontap-formula/_modules/ontap.py
@@ -173,10 +173,13 @@ def _parse_size(size):
     number, unit = [string.strip() for string in size.split()]
     return int(float(number)*units[unit])
 
-def provision_lun(name, size, lunid, volume, vserver):
+def provision_lun(name, size, volume, vserver, comment=None):
     varmap = _config()
     size = _parse_size(size)
-    varmap.update({'playbook': 'playbooks/deploy-lun_restit.yml', 'extravars': {'ontap_comment': name, 'ontap_lun_id': lunid, 'ontap_volume': volume, 'ontap_vserver': vserver, 'ontap_size': size}})
+    path = _path(volume, name)
+    varmap.update({'playbook': 'playbooks/deploy-lun_restit.yml', 'extravars': {'ontap_lun_path': path, 'ontap_volume': volume, 'ontap_vserver': vserver, 'ontap_size': size}})
+    if comment is not None:
+        varmap['extravars'].update({'ontap_comment': comment})
     result = _call(**varmap)
     return _result(result)
 

--- a/netapp_ontap-formula/_states/ontap.py
+++ b/netapp_ontap-formula/_states/ontap.py
@@ -1,0 +1,248 @@
+"""
+Salt state module for managing LUNs using the ONTAP Ansible collection
+Copyright (C) 2023 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import logging
+log = logging.getLogger(__name__)
+
+# Source: https://stackoverflow.com/a/14996816
+suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+def _humansize(nbytes):
+    i = 0
+    while nbytes >= 1024 and i < len(suffixes)-1:
+        nbytes /= 1024.
+        i += 1
+    f = ('%.2f' % nbytes).rstrip('0').rstrip('.')
+    return '%s%s' % (f, suffixes[i])
+
+# https://stackoverflow.com/a/60708339
+# based on https://stackoverflow.com/a/42865957/2002471
+units = {"B": 1, "KB": 2**10, "MB": 2**20, "GB": 2**30, "TB": 2**40}
+def _parse_size(size):
+    size = size.upper()
+    #print("parsing size ", size)
+    if not re.match(r' ', size):
+        size = re.sub(r'([KMGT]?B)', r' \1', size)
+    number, unit = [string.strip() for string in size.split()]
+    return int(float(number)*units[unit])
+
+def lun_present(name, comment, size, volume, vserver, lunid=None, igroup=None):
+    path = f'/vol/{volume}/{name}'
+    ret = {'name': path, 'result': False, 'changes': {}, 'comment': ''}
+    size_ok = False
+    map_ok = False
+    if not None in [lunid, igroup]:
+        do_map = True
+    else:
+        do_map = False
+
+    def _size(details, human=False):
+        size = details.get('space', {}).get('size')
+        if size is not None and human:
+            return _humansize(size)
+        return size
+
+    # FIXME drop mapping logic from lun_present in favor of lun_mapped
+    def _map(name, lunid, volume, vserver, igroup):
+        ok = False
+        map_out = __salt__['ontap.map_lun'](name, lunid, volume, vserver, igroup)
+        if map_out.get('result', False) and map_out.get('status') == 201:
+            comment = f'Mapped LUN to ID {lunid}'
+            ok = True
+            # consider another get_lun to validate .. given the queries being expensive in time, it should be combined with the resize validation
+        else:
+            comment = 'LUN mapping failed'
+        return comment, ok
+
+    query = __salt__['ontap.get_lun'](get_next_free=True)
+    luns = query[0]
+    next_free = query[1]
+
+    for lun in luns:
+        lun_path = lun.get('name')
+        lun_comment = lun.get('comment')
+        lun_uuid = lun.get('uuid')
+        if lun_comment == comment or lun_path == path:
+            log.debug(f'netapp_ontap: found existing LUN {name}')
+            if lun_uuid is None:
+                log.error(f'netapp_ontap: found LUN with no UUID')
+            lun_details = __salt__['ontap.get_lun'](uuid=lun_uuid)
+            lun_size = _size(lun_details[0], True)
+            # lun_size_human = needed?
+            lun_mapping = __salt__['ontap.get_lun_mapped'](lun_result=lun_details)
+            lun_mapped = lun_mapping.get(name)
+            # lun_id = needed?
+            if lun_size == size:
+                comment_size = f'Size {size} matches'
+                size_ok = True
+            elif lun_size != size:
+                if __opts__['test']:
+                    comment_size = f'Would resize LUN to {size}'
+                else:
+                    __salt__['ontap.update_lun'](name, size, volume, vserver)
+                    lun2_details = __salt__['ontap.get_lun'](uuid=lun_uuid)
+                    lun2_size = _size(lun2_details[0], True)
+                    comment_size = f'LUN from {lun_size} to {size}'
+                    if lun2_size != lun_size and lun2_size == size:
+                        comment_size = f'Sucessfully resized {comment_size}'
+                        size_ok = True
+                    elif lun2_size == lun_size:
+                        comment_size = f'Failed to resize {comment_size}, it is still {lun2_size}'
+                    else:
+                        comment_size = f'Unexpected outcome while resizing {comment_size}'
+
+            if not do_map:
+                comment_mapping = None
+                map_ok = True
+            else:
+                if lun_mapped:
+                    comment_mapping = 'Already mapped'
+                    map_ok = True
+                else:
+                    map_out = _map(name, lunid, volume, vserver, igroup)
+                    comment_mapping = map_out[0]
+                    map_ok = map_out[1]
+
+                    #map_out = __salt__['ontap.map_lun'](name, lunid, volume, vserver, igroup)
+                    #if map_out.get('result', False) and map_out.get('status') == 201:
+                    #    comment_mapping = f'Mapped LUN to ID {lunid}'
+                    #    map_ok = True
+                    #    # consider another get_lun to validate .. given the queries being expensive in time, it should be combined with the resize validation
+                    #else:
+                    #    comment_mapping = 'LUN mapping failed'
+
+            comment_base = 'LUN is already present'
+            if size_ok and map_ok:
+                ret['result'] = True
+            retcomment = f'{comment_base}; {comment_size}'
+            if comment_mapping is not None:
+                retcomment = f'{retcomment}, {comment_mapping}'
+            if __opts__['test']:
+                ret['result'] = None
+            ret['comment'] = retcomment
+            return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'Would provision LUN'
+        ret['result'] = None
+        return ret
+
+    __salt__['ontap.provision_lun'](name, size, volume, vserver, comment)
+    if do_map:
+        map_out = _map(name, lunid, volume, vserver, igroup)
+        comment_mapping = map_out[0]
+        map_ok = map_out[1]
+    lun2_details = __salt__['ontap.get_lun'](comment)
+    lun2_size = _size(lun2_details)
+    # FIXME changes dict
+
+    if lun2_details.get('name') == path:
+        ret['result'] = True
+        comment_path = f'{path} created'
+    else:
+        ret['result'] = False
+        comment_path = f'{path} not properly created'
+
+    if lun2_size == size:
+        ret['result'] = True
+        comment_size = f'with size {size}'
+    else:
+        ret['result'] = False
+        comment_size = f'with mismatching size {lun2_size}'
+
+    comment = f'LUN {comment_path} {comment_size}.'
+
+    if do_map:
+        if map_ok:
+            ret['result'] = True
+            comment_mapping = f'mapped to ID {lunid}'
+        else:
+            ret['result'] = False
+            comment_mapping = f'mapping to ID {lunid} failed'
+        comment = f'{comment} LUN {comment_mapping}.'
+
+    ret['comment'] = comment
+    return ret
+
+def lun_mapped(name, lunid, volume, vserver, igroup):
+    path = f'/vol/{volume}/{name}'
+    ret = {'name': path, 'result': False, 'changes': {}, 'comment': ''}
+
+    mapping_out = __salt__['ontap.get_lun_mapping'](name, volume, igroup)
+    log.debug(f'netapp_ontap: mapping result: {mapping_out}')
+    current_igroups = []
+    current_svms = []
+    records = mapping_out.get('num_records')
+    do_igroup = True
+    do_svm = True
+    do_map = False
+    if records == 0:
+        do_map = True
+        if __opts__['test']:
+            comment = 'Would create mapping'
+    elif records is not None and records > 0:
+        for mapping in mapping_out.get('records', []):
+            this_igroup = mapping.get('igroup', {}).get('name')
+            if this_igroup is None:
+                log.error(f'netapp_ontap: unable to determine igroup in mapping result')
+            else:
+                if this_igroup not in current_igroups:
+                    current_igroups.append(this_igroup)
+            this_svm = mapping.get('svm', {}).get('name')
+            if this_svm is None:
+                log.error(f'netapp_ontap: unable to determine svm in mapping result')
+            else:
+                if this_svm not in current_svms:
+                    current_svms.append(this_svm)
+
+    comment_igroup = f' to igroup {igroup}'
+    if igroup in current_igroups:
+        do_igroup = False
+
+    comment_svm = f' in SVM {vserver}'
+    if vserver in current_svms:
+        do_svm = False
+
+    comments = f'{comment_igroup}{comment_svm}'
+    already = False
+    if do_map or do_igroup or do_svm:
+        if __opts__['test']:
+            comment = f'Would map ID {lunid}{comments}'
+    elif not do_igroup or not do_svm:
+        comment = f'Already mapped{comment_igroup}{comment_svm}'
+        ret['result'] = True
+    else:
+        log.error('Unhandled mapping state')
+        comment = 'Something weird happened'
+
+    if __opts__['test']:
+        ret['result'] = None
+    if __opts__['test'] or ret['result'] is True:
+        ret['comment'] = comment
+        return ret
+
+    map_out = __salt__['ontap.map_lun'](name, lunid, volume, vserver, igroup)
+    if map_out.get('result', False) and map_out.get('status') == 201:
+        comment = f'Mapped LUN to ID {lunid} in igroup {igroup}'
+        ret['result'] = True
+    else:
+        comment = 'LUN mapping failed'
+        ret['result'] = False
+
+    ret['comment'] = comment
+    return ret
+

--- a/netapp_ontap-formula/_utils/ontap_config.py
+++ b/netapp_ontap-formula/_utils/ontap_config.py
@@ -1,0 +1,32 @@
+"""
+Salt utility module for providing functions used by other ONTAP related modules
+Copyright (C) 2023 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import logging
+
+log = logging.getLogger(__name__)
+
+def config():
+    config = __pillar__.get('netapp_ontap', {})
+    host = config.get('host')
+    certificate = config.get('certificate')
+    key = config.get('key')
+    rundir = config.get('rundir')
+    if None in [host, certificate, key, rundir]:
+        log.error('netapp_ontap: configuration is incomplete!')
+        return False
+    return {'host': host, 'certificate': certificate, 'key': key, 'rundir': rundir}

--- a/netapp_ontap-formula/ansible/README.md
+++ b/netapp_ontap-formula/ansible/README.md
@@ -1,0 +1,1 @@
+The Ansible playbooks and tasks are intended to be run by the Salt `ontap` module, however can be run directly if the variables are correctly set.

--- a/netapp_ontap-formula/ansible/playbooks/delete-lun_restit.yml
+++ b/netapp_ontap-formula/ansible/playbooks/delete-lun_restit.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  name: Delete LUN
+  connection: local
+  gather_facts: False
+
+  tasks:
+    - name: Delete
+      block:
+        - name: Delete LUN
+          import_tasks: "{{ '../tasks/delete_lun_restit.yml' if ontap_lun_uuid is defined else '../tasks/delete_lun_restit_by_path.yml' }}"

--- a/netapp_ontap-formula/ansible/playbooks/deploy-lun_restit.yml
+++ b/netapp_ontap-formula/ansible/playbooks/deploy-lun_restit.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  name: Create LUN
+  connection: local
+  gather_facts: False
+
+  tasks:
+    - name: Deploy
+      block:
+        - name: Create LUN
+          import_tasks: '../tasks/create_lun_restit.yml'

--- a/netapp_ontap-formula/ansible/playbooks/fetch-lun-by-comment_restit.yml
+++ b/netapp_ontap-formula/ansible/playbooks/fetch-lun-by-comment_restit.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  name: Get LUN
+  connection: local
+  gather_facts: False
+
+  tasks:
+    - name: Gather details
+      block:
+        - name: Query LUN
+          import_tasks: '../tasks/get_lun_by_name_restit.yml'
+

--- a/netapp_ontap-formula/ansible/playbooks/fetch-lun_restit.yml
+++ b/netapp_ontap-formula/ansible/playbooks/fetch-lun_restit.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  name: Query LUN
+  connection: local
+  gather_facts: False
+
+  tasks:
+    - name: Gather details
+      block:
+        - name: Query LUN
+          import_tasks: '../tasks/get_lun_restit.yml'
+

--- a/netapp_ontap-formula/ansible/playbooks/fetch-luns_restit.yml
+++ b/netapp_ontap-formula/ansible/playbooks/fetch-luns_restit.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  name: Query LUNs
+  connection: local
+  gather_facts: False
+
+  tasks:
+    - name: Gather details
+      block:
+        - name: Query LUNs
+          import_tasks: '../tasks/get_luns_restit.yml'
+

--- a/netapp_ontap-formula/ansible/playbooks/get-lun-mapping_restit.yml
+++ b/netapp_ontap-formula/ansible/playbooks/get-lun-mapping_restit.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  name: Create LUN
+  connection: local
+  gather_facts: False
+
+  tasks:
+    - name: Deploy
+      block:
+        - name: Map LUN
+          import_tasks: '../tasks/get_lun_mapping_restit.yml'

--- a/netapp_ontap-formula/ansible/playbooks/map-lun_restit.yml
+++ b/netapp_ontap-formula/ansible/playbooks/map-lun_restit.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  name: Create LUN
+  connection: local
+  gather_facts: False
+
+  tasks:
+    - name: Deploy
+      block:
+        - name: Map LUN
+          import_tasks: '../tasks/map_lun_restit.yml'

--- a/netapp_ontap-formula/ansible/playbooks/patch-lun_restit.yml
+++ b/netapp_ontap-formula/ansible/playbooks/patch-lun_restit.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  name: Patch LUN
+  connection: local
+  gather_facts: False
+
+  tasks:
+    - name: Deploy
+      block:
+        - name: Patch LUN
+          import_tasks: '../tasks/patch_lun_restit.yml'

--- a/netapp_ontap-formula/ansible/playbooks/unmap-lun_restit.yml
+++ b/netapp_ontap-formula/ansible/playbooks/unmap-lun_restit.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  name: Create LUN
+  connection: local
+  gather_facts: False
+
+  tasks:
+    - name: Deploy
+      block:
+        - name: Map LUN
+          import_tasks: '../tasks/unmap_lun_restit.yml'

--- a/netapp_ontap-formula/ansible/tasks/create_lun_restit.yml
+++ b/netapp_ontap-formula/ansible/tasks/create_lun_restit.yml
@@ -1,0 +1,22 @@
+---
+- name: Create LUN
+  netapp.ontap.na_ontap_restit:
+    hostname: '{{ ontap_host }}'
+    cert_filepath: '{{ ontap_crt }}'
+    key_filepath: '{{ ontap_key }}'
+    http_port: '{{ ontap_port }}'
+    use_rest: always
+    validate_certs: false
+    api: storage/luns
+    method: POST
+    body:
+      name: '{{ ontap_lun_path }}'
+      comment: "{{ ontap_comment if ontap_comment is defined else 'Provisioned by Ansible'}}"
+      svm: '{{ ontap_vserver }}'
+      space:
+        size: '{{ ontap_size }}'
+      os_type: linux
+  register: lun_create_info
+
+- debug: var=lun_create_info
+- assert: { that: lun_create_info.status_code==201 }

--- a/netapp_ontap-formula/ansible/tasks/delete_lun_restit.yml
+++ b/netapp_ontap-formula/ansible/tasks/delete_lun_restit.yml
@@ -1,0 +1,16 @@
+---
+- name: Delete LUN
+  netapp.ontap.na_ontap_restit:
+    hostname: '{{ ontap_host }}'
+    cert_filepath: '{{ ontap_crt }}'
+    key_filepath: '{{ ontap_key }}'
+    http_port: '{{ ontap_port }}'
+    use_rest: always
+    validate_certs: false
+    api: 'storage/luns'
+    method: DELETE
+    query:
+      uuid: '{{ ontap_lun_uuid }}'
+  register: lun_delete_info
+
+- assert: { that: lun_delete_info.status_code==200 }

--- a/netapp_ontap-formula/ansible/tasks/delete_lun_restit_by_path.yml
+++ b/netapp_ontap-formula/ansible/tasks/delete_lun_restit_by_path.yml
@@ -1,0 +1,17 @@
+---
+- name: Delete LUN
+  netapp.ontap.na_ontap_restit:
+    hostname: '{{ ontap_host }}'
+    cert_filepath: '{{ ontap_crt }}'
+    key_filepath: '{{ ontap_key }}'
+    http_port: '{{ ontap_port }}'
+    use_rest: always
+    validate_certs: false
+    api: 'storage/luns'
+    method: DELETE
+    query:
+      name: '/vol/{{ ontap_volume }}/{{ ontap_lun_name }}'
+  register: lun_delete_info
+
+- debug: var=lun_delete_info
+- assert: { that: lun_delete_info.status_code==200 }

--- a/netapp_ontap-formula/ansible/tasks/get_lun_by_name_restit.yml
+++ b/netapp_ontap-formula/ansible/tasks/get_lun_by_name_restit.yml
@@ -1,0 +1,17 @@
+---
+- name: Get LUN
+  netapp.ontap.na_ontap_restit:
+    hostname: '{{ ontap_host }}'
+    cert_filepath: '{{ ontap_crt }}'
+    key_filepath: '{{ ontap_key }}'
+    http_port: '{{ ontap_port }}'
+    use_rest: always
+    validate_certs: false
+    wait_for_completion: true
+    api: 'storage/luns'
+    query:
+      comment: '{{ ontap_lun_comment }}'
+      fields: 'space,status.mapped'
+  register: lun_info
+
+- assert: { that: lun_info.status_code==200 }

--- a/netapp_ontap-formula/ansible/tasks/get_lun_mapping_restit.yml
+++ b/netapp_ontap-formula/ansible/tasks/get_lun_mapping_restit.yml
@@ -1,0 +1,18 @@
+---
+- name: Map LUN
+  netapp.ontap.na_ontap_restit:
+    hostname: '{{ ontap_host }}'
+    http_port: '{{ ontap_port }}'
+    cert_filepath: '{{ ontap_crt }}'
+    key_filepath: '{{ ontap_key }}'
+    use_rest: always
+    validate_certs: false
+    api: protocols/san/lun-maps
+    query:
+      igroup: '{{ ontap_igroup }}'
+      lun: '{{ ontap_lun_path }}'
+  register: lun_map_out
+
+- debug: var=lun_map_out
+- assert: { that: lun_map_out.status_code==200 }
+

--- a/netapp_ontap-formula/ansible/tasks/get_lun_restit.yml
+++ b/netapp_ontap-formula/ansible/tasks/get_lun_restit.yml
@@ -1,0 +1,17 @@
+---
+- name: Get LUN
+  netapp.ontap.na_ontap_restit:
+    hostname: '{{ ontap_host }}'
+    cert_filepath: '{{ ontap_crt }}'
+    key_filepath: '{{ ontap_key }}'
+    http_port: '{{ ontap_port }}'
+    use_rest: always
+    validate_certs: false
+    wait_for_completion: true
+    api: 'storage/luns'
+    query:
+      uuid: '{{ ontap_lun_uuid }}'
+      fields: 'space,status.mapped'
+  register: lun_info
+
+- assert: { that: lun_info.status_code==200 }

--- a/netapp_ontap-formula/ansible/tasks/get_luns_restit.yml
+++ b/netapp_ontap-formula/ansible/tasks/get_luns_restit.yml
@@ -1,0 +1,36 @@
+---
+- name: Get LUNs
+  netapp.ontap.na_ontap_restit:
+    hostname: '{{ ontap_host }}'
+    cert_filepath: '{{ ontap_crt }}'
+    key_filepath: '{{ ontap_key }}'
+    http_port: '{{ ontap_port }}'
+    use_rest: always
+    validate_certs: false
+    wait_for_completion: true
+    api: storage/luns
+    query:
+      fields: comment
+  register: lun_info
+- debug: var=lun_info
+- assert: { that: lun_info.status_code==200 }
+
+- name: Store LUN dump
+  local_action:
+    module: copy
+    content: '{{ lun_info }}'
+    dest: /dev/shm/luns.out
+
+# I'm sure there's a native way to do this...
+- name: Get highest LUN
+  ansible.builtin.shell:
+    cmd: "grep -Po 'lun\\K(\\d+)' /dev/shm/luns.out | sort -nu | tail -n1"
+  register: lun_grep
+
+- name: Define LUN number
+  set_fact:
+    lun_id: '{{ lun_grep.stdout | int + 1 }}'
+
+- name: Dump gathered variables
+  ansible.builtin.debug:
+    msg: 'LUN ID defined as {{ lun_id }}'

--- a/netapp_ontap-formula/ansible/tasks/map_lun_restit.yml
+++ b/netapp_ontap-formula/ansible/tasks/map_lun_restit.yml
@@ -1,0 +1,24 @@
+---
+- name: Map LUN
+  netapp.ontap.na_ontap_restit:
+    hostname: '{{ ontap_host }}'
+    http_port: '{{ ontap_port }}'
+    cert_filepath: '{{ ontap_crt }}'
+    key_filepath: '{{ ontap_key }}'
+    use_rest: always
+    validate_certs: false
+    api: protocols/san/lun-maps
+    method: POST
+    body:
+      svm:
+        name: '{{ ontap_vserver }}'
+      igroup:
+        name: '{{ ontap_igroup }}'
+      lun:
+        name: '{{ ontap_lun_path }}'
+      logical_unit_number: '{{ ontap_lun_id }}'
+  register: lun_map_out
+
+- debug: var=lun_map_out
+- assert: { that: lun_map_out.status_code==201 }
+

--- a/netapp_ontap-formula/ansible/tasks/patch_lun_restit.yml
+++ b/netapp_ontap-formula/ansible/tasks/patch_lun_restit.yml
@@ -1,0 +1,25 @@
+---
+- name: Patch LUN
+  netapp.ontap.na_ontap_restit:
+    hostname: '{{ ontap_host }}'
+    cert_filepath: '{{ ontap_crt }}'
+    key_filepath: '{{ ontap_key }}'
+    http_port: '{{ ontap_port }}'
+    use_rest: always
+    validate_certs: false
+    api: storage/luns
+    method: PATCH
+    query:
+      name: '{{ ontap_lun_path }}'
+    body:
+      space:
+        size: '{{ ontap_size }}'
+  register: lun_patch_info
+
+- debug: var=lun_patch_info
+- assert: { that: lun_patch_info.status_code==200 }
+
+- local_action:
+    module: copy
+    content: '{{ lun_patch_info }}'
+    dest: /tmp/lun_patch.out

--- a/netapp_ontap-formula/ansible/tasks/unmap_lun_restit.yml
+++ b/netapp_ontap-formula/ansible/tasks/unmap_lun_restit.yml
@@ -1,0 +1,19 @@
+---
+- name: Map LUN
+  netapp.ontap.na_ontap_restit:
+    hostname: '{{ ontap_host }}'
+    http_port: '{{ ontap_port }}'
+    cert_filepath: '{{ ontap_crt }}'
+    key_filepath: '{{ ontap_key }}'
+    use_rest: always
+    validate_certs: false
+    api: protocols/san/lun-maps
+    method: DELETE
+    query:
+      igroup: '{{ ontap_igroup }}'
+      lun: '{{ ontap_lun_path }}'
+  register: lun_unmap_out
+
+- debug: var=lun_unmap_out
+- assert: { that: lun_unmap_out.status_code==200 }
+


### PR DESCRIPTION
This is intended to become a replacement for the messy LUN management code in the orchestra formula. The functionality is now implemented with proper Salt modules and correct `test=True` operation, and is easily expandable for ONTAP operations beyond LUN management. Ironically, this replacement still uses Ansible as a middleware, but the new layout should make switching to direct interaction with the NetApp Python library easier should this be desired in the future.