### PR TITLE
zypper: add packages_legacy

### DIFF
--- a/zypper-formula/zypper/init.sls
+++ b/zypper-formula/zypper/init.sls
@@ -1,4 +1,8 @@
 include:
   - zypper.config
   - zypper.repositories
+  {%- if grains['osmajorrelease'] < 15 %}
+  - zypper.packages_legacy
+  {%- else %}
   - zypper.packages
+  {%- endif %}

--- a/zypper-formula/zypper/packages_legacy.sls
+++ b/zypper-formula/zypper/packages_legacy.sls
@@ -1,0 +1,13 @@
+{% set packages = salt['pillar.get']('zypper:packages', {}) %}
+
+{% for package, data in packages.items() %}
+zypper_pkg_{{ package }}:
+  pkg.installed:
+    - name: {{ package }}
+    {% if 'refresh' in data %}
+    - refresh: {{ data.refresh }}
+    {% endif %}
+    {% if 'fromrepo' in data %}
+    - fromrepo: {{ data.fromrepo }}
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
SLES 12 based systems do not support Jinja namespaces. Import the pre-b37fd8225054da8afca2600260da8830289982ce version of packages.sls as packages_legacy.sls and include it if run on a SUSE release lower than 15. This patch should be dropped once our infrastructures are freed from SLES 12 systems.

Resolves https://github.com/openSUSE/salt-formulas/issues/30.

Pending testing.