### PR TITLE
suse_ha: handle missing cluster name

### DIFF
--- a/suse_ha-formula/suse_ha/map.jinja
+++ b/suse_ha-formula/suse_ha/map.jinja
@@ -54,7 +54,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- set host = grains['host'] -%}
 {%- set id = grains['id'] -%}
 
-{%- set nodes = salt['mine.get'](cluster.name ~ '*', 'network.get_hostname') | sort -%}
+{%- set clustername = cluster.get('name') -%}
+{%- if clustername is none -%}
+{%- set nodes = [] -%}
+{%- else -%}
+{%- set nodes = salt['mine.get'](clustername ~ '*', 'network.get_hostname') | sort -%}
+{%- endif -%}
 {%- if nodes | length -%}
 {%- set primary = nodes[0] -%}
 {%- do salt.log.debug('suse_ha: elected primary node is ' ~ primary) -%}


### PR DESCRIPTION
The formula referencing cluster.name caused errors for machines without any suse_ha pillar data.

This imports the downstream patch from https://build.opensuse.org/package/view_file/isv:SUSEInfra:Tools/infrastructure-formulas/clustername.patch?expand=1.