### PR TITLE
Update deploy_password pillar reference

### DIFF
--- a/infrastructure-formula/infrastructure/salt/files/usr/local/sbin/saltmaster-deploy.j2
+++ b/infrastructure-formula/infrastructure/salt/files/usr/local/sbin/saltmaster-deploy.j2
@@ -16,5 +16,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-{%- set deploy_password = salt['pillar.get']('infrastructure:salt:reactor:update_fileserver_deploy_password', '') %}
+{%- set deploy_password = salt['pillar.get']('infrastructure:salt:reactor:update_fileserver:deploy_password', '') %}
 salt-call event.fire_master {{ deploy_password }} salt/fileserver/gitfs/update


### PR DESCRIPTION
Facilitate the change from a7403333c8300e0c109cf1394e437e2dbb9d536b and reference deploy_password from underneath the update_fileserver dict.