### PR TITLE
Add Git garbage collection to infrastructure.salt

### DIFF
--- a/infrastructure-formula/infrastructure/salt/files/etc/systemd/system/salt-git-gc.service
+++ b/infrastructure-formula/infrastructure/salt/files/etc/systemd/system/salt-git-gc.service
@@ -1,0 +1,31 @@
+# Service to clean up Git directories used by Salt.
+# Copyright (C) 2023 Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+[Unit]
+Description=Git garbage collection for Salt
+Documentation=https://github.com/openSUSE/salt-formulas
+
+[Service]
+Type=oneshot
+User=salt
+ExecStart=bash -c '\
+                for topdir in gitfs git_pillar ; do \
+                basedir=/var/cache/salt/master/$topdir ; \
+                if ! test -d $basedir; then exit 0; fi ; \
+                while read lowdir ; do echo $basedir/$lowdir ; \
+                git --git-dir=$basedir/$lowdir/.git gc ; done \
+                < <(awk "!/^#/{ print \\$1 }" $basedir/remote_map.txt) ; done'
+SyslogIdentifier=git-gc

--- a/infrastructure-formula/infrastructure/salt/files/etc/systemd/system/salt-git-gc.timer
+++ b/infrastructure-formula/infrastructure/salt/files/etc/systemd/system/salt-git-gc.timer
@@ -1,0 +1,25 @@
+# Timer to trigger the salt-git-gc service on a schedule.
+# Copyright (C) 2023 Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+[Unit]
+Description=Run scheduled Git garbage collection for Salt
+Documentation=https://github.com/openSUSE/salt-formulas
+
+[Timer]
+OnCalendar=daily
+
+[Install]
+WantedBy=timers.target

--- a/infrastructure-formula/infrastructure/salt/master.sls
+++ b/infrastructure-formula/infrastructure/salt/master.sls
@@ -40,3 +40,17 @@ salt_master_extra_packages:
   file.recurse:
     - source: salt://infrastructure/salt/files/srv/reactor
     - template: jinja
+
+{%- if salt['pillar.get']('infrastructure:salt:master:git_gc', False) %}
+salt_git_gc:
+  file.managed:
+    - names:
+    {%- for suffix in ['timer', 'service'] %}
+    {%- set unit = '/etc/systemd/system/salt-git-gc.' ~ suffix %}
+      - {{ unit }}:
+        - source: salt://{{ slspath }}/files/{{ unit }}
+    {%- endfor %}
+  service.running:
+    - name: salt-git-gc.timer
+    - enable: true
+{%- endif %}


### PR DESCRIPTION
Salt does not handle this by itself
(https://github.com/saltstack/salt/issues/61056) and disk space consumption became an issue on some of our Salt masters.