### PR TITLE
network: facilitate IPv6 default routes

### DIFF
--- a/network-formula/network/wicked/files/usr/local/sbin/saltsafe_if
+++ b/network-formula/network/wicked/files/usr/local/sbin/saltsafe_if
@@ -119,7 +119,7 @@ run_test() {
 		# Get routes passed by Salt on the command line
 		desired_routes="$(echo $routes | tr ',' '\n' | sort)"
 		# Get active routes, exclude non-administratively configured ones
-		existing_routes=$({ ip -br -4 r; ip -br -6 r; } | sort -u | awk '!/^(fe80|::1)|scope link/{ print $1 "_" $3 }')
+		existing_routes=$({ ip -br -4 r; ip -br -6 r; } | sort -u | awk '!/^(fe80::\/|::1)|scope link/{ print $1 "_" $3 }')
 		if [ "${desired_routes}" == "${existing_routes}" ]
 		then
 			result="changed=no comment='Routes are already correctly configured.'"

--- a/network-formula/network/wicked/routes.sls
+++ b/network-formula/network/wicked/routes.sls
@@ -40,6 +40,9 @@ network_wicked_routes:
     - contents:
         - {{ pillar.get('managed_by_salt_formula', '# Managed by the network formula') | yaml_encode }}
       {%- for route, config in routes.items() %}
+      {%- if route in ['default4', 'default6'] %}
+      {%- set route = 'default' %}
+      {%- endif %}
       {%- do shell_routes.append(route ~ '_' ~ config.get('gateway', '')) %}
         -  {{ route }} {{ config.get('gateway', '-') }} {{ config.get('netmask', '-') }} {{ config.get('interface', '-') }} {{ ' '.join(config.get('options', [])) }}
       {%- endfor %}

--- a/network-formula/pillar.example
+++ b/network-formula/pillar.example
@@ -31,8 +31,14 @@ network:
         - 192.168.101.1/24
         - fe80::1/64
   # each listed route will be written into /etc/sysconfig/network/routes and applied
+  # "default4" and "default6" will be written as "default"
   routes:
-    default:
+    default4:
       gateway: 192.168.120.1
-    10.0.10.10/32:
+    default6:
+      gateway: fe80::1
+      interface: eth0
+    10.0.10.1/32:
       gateway: 192.168.120.2
+      options:
+        - blackhole


### PR DESCRIPTION
This allows for duplicate keys, as is required for dual stack "default" entries.
The example pillar is additionally expanded to highlight the syntax for all available fields.