### PR TITLE
saltsafe_if: support IPv6 and Syndic addresses, repair backup handling

### DIFF
--- a/network-formula/network/wicked/files/usr/local/sbin/saltsafe_if
+++ b/network-formula/network/wicked/files/usr/local/sbin/saltsafe_if
@@ -235,7 +235,7 @@ file="$base/$filename"
 file_backup="$base_backup/$filename"
 
 # Get IP addresses of the Salt minion and master
-read minion_ip master_ip < <(ss -HntA tcp dst :4505 | awk '{ split($4, con_out, ":"); split($5, con_in, ":"); print con_out[1] " " con_in[1] }')
+read minion_ip master_ip < <(ss -HntA tcp dst :4505 | awk 'END { gsub(/\[|\]/,""); split($4, con_out, /:[[:digit:]]{4,5}$/); split($5, con_in, /:[[:digit:]]{4,5}$/); print con_out[1] " " con_in[1] }')
 
 if [ -z "$minion_ip" -o -z "$master_ip" ]
 then

--- a/network-formula/network/wicked/files/usr/local/sbin/saltsafe_if
+++ b/network-formula/network/wicked/files/usr/local/sbin/saltsafe_if
@@ -108,7 +108,10 @@ backup() {
 	then
 		old "$file_backup" >/dev/null
 	fi
-	cp "$file" "$file_backup"
+	if [ -f "$file" ]
+	then
+		cp "$file" "$file_backup"
+	fi
 }
 
 run_test() {
@@ -221,18 +224,18 @@ else
 		fail "Unable to locate $call."
 	fi
 
-	if [ ! -f "$base_backup/ifcfg-$interface" ]
-	then
-		if [ "$extra" != 'test' ]
-		then
-			#fail "Missing backup configuration for interface $interface, refusing to operate."
-			backup
-		fi
-	fi
 fi
 
 file="$base/$filename"
 file_backup="$base_backup/$filename"
+
+if [ ! -f "$file_backup" ]
+then
+	if [ "$extra" != 'test' ]
+	then
+		backup
+	fi
+fi
 
 # Get IP addresses of the Salt minion and master
 read minion_ip master_ip < <(ss -HntA tcp dst :4505 | awk 'END { gsub(/\[|\]/,""); split($4, con_out, /:[[:digit:]]{4,5}$/); split($5, con_in, /:[[:digit:]]{4,5}$/); print con_out[1] " " con_in[1] }')


### PR DESCRIPTION
- Handle IPv6 addresses correctly whilst keeping support for IPv4
- Read only last pair of addresses in case of multiple master connections
- In some situations, the script might fail with an unbound variable due
    to backup() being called before the $file_backup declaration. This is
    now resolved - additionally, a check for an existing origin file is
    implemented, in case backup() is called before the origin file has been
    written for the first time.