### PR TITLE
Allow non-orchestraed suse_ha.resources

### DIFF
--- a/infrastructure-formula/infrastructure/suse_ha/resources.sls
+++ b/infrastructure-formula/infrastructure/suse_ha/resources.sls
@@ -19,17 +19,18 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- from 'suse_ha/macros.jinja' import ha_resource -%}
 
 {#- virtual machine resources below are constructed if instructed by the deploy_vm orchestration state #}
-{%- if pillar['do_vd'] | default(False) %}
-{%- if 'delegated_orchestra' in pillar %}
+{%- if pillar['do_vd'] | default(False) and 'delegated_orchestra' in pillar %}
+{%- do salt.log.debug('suse_ha.resources: delegated from orchestration run') -%}
 {%- set dopillar = pillar['delegated_orchestra'] -%}
 {%- set lowpillar = dopillar['lowpillar'] -%}
 {%- set domain = dopillar['domain'] -%}
 {%- else %}
+{%- do salt.log.debug('suse_ha.resources: running non-orchestrated') -%}
 {%- set lowpillar = salt['pillar.get']('infrastructure') -%}
 {%- set domain = grains['domain'] -%}
 {%- endif %}
 {%- set myid = grains['id'] -%}
-{%- set cluster = grains['virt_cluster'] -%}
+{%- set cluster = grains['virt_cluster'].replace('-bare','') -%}
 {%- if not 'domains' in lowpillar -%}
 {%- do salt.log.error('Incomplete orchestration pillar - verify whether the orchestrator role is assigned.') -%}
 {%- elif not domain in lowpillar['domains'] -%}
@@ -69,13 +70,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       'migration-threshold': 0
 } %}
 
-{{ ha_resource('VM_' ~ machine, 'ocf', 'VirtualDomain', instance_attributes, operations, meta_attributes, 'heartbeat') }}
+{{ ha_resource('VM_' ~ machine, 'ocf', 'VirtualDomain', instance_attributes, operations, meta_attributes, 'heartbeat', requires=None) }}
 
 {%- endif %}
 {%- endfor %}
 {%- endif %}
 {%- endif %}
-{%- endif %}
-{%- else %}
-{%- do salt.log.debug('Skipping construction of Virtual Domain resources') %}
 {%- endif %}

--- a/suse_ha-formula/suse_ha/macros.jinja
+++ b/suse_ha-formula/suse_ha/macros.jinja
@@ -42,11 +42,13 @@ ha_resource_file_{{ resource }}:
             operations: {{ operations }}
             meta_attributes: {{ meta_attributes }}
             provider: {{ provider }}
+    {%- if requires is not none %}
     - require:
       - file: ha_resources_directory
       {%- for require in requires %}
       - {{ require }}
       {%- endfor %}
+    {%- endif %}
 
 ha_resource_update_{{ resource }}:
   cmd.run:


### PR DESCRIPTION
This adapts the logic to the one used within
infrastructure.libvirt.domains, which allows for operation outside of an orchestration state.