### PR TITLE
Prevent failure on non-existing ifcfg files

### DIFF
--- a/network-formula/network/wicked/interfaces.sls
+++ b/network-formula/network/wicked/interfaces.sls
@@ -85,18 +85,26 @@ include:
 {%- endfor %}
 
 {%- if ifcfg_data %}
+
+{%- set interface_files = {} %}
+{%- for interface in ifcfg_data.keys() %}
+{%- set file = base ~ '/ifcfg-' ~ interface %}
+{%- if salt['file.file_exists'](file) %}
+{%- do interface_files.update({interface: file}) %}
+{%- endif %}
+{%- endfor %} {#- close interface loop #}
+
+{%- if interface_files %}
 network_wicked_ifcfg_backup:
   file.copy:
     - names:
-      {%- for interface in ifcfg_data.keys() %}
-      {%- set file = base ~ '/ifcfg-' ~ interface %}
-      {%- if salt['file.file_exists'](file) %}
+      {%- for interface, file in interface_files.items() %}
       - {{ base_backup }}/ifcfg-{{ interface }}:
         - source: {{ file }}
-      {%- endif %}
       {%- endfor %}
     - require:
       - file: network_wicked_backup_directory
+{%- endif %} {#- close interface_files check #}
 
 network_wicked_ifcfg_settings:
   file.managed:


### PR DESCRIPTION
If a single interface was configured but no existing ifcfg file existed on the system, the Salt state would render invalid due to an empty list being presented. This is now mitigated by scanning the files before rendering the affected block.