### PR TITLE
Skip backup file requisites if state is skipped

### DIFF
--- a/network-formula/network/wicked/interfaces.sls
+++ b/network-formula/network/wicked/interfaces.sls
@@ -125,8 +125,10 @@ network_wicked_ifcfg_settings:
           {%- endfor %}
       {%- endfor %}
     - mode: '0640'
+    {%- if interface_files %}
     - require:
       - file: network_wicked_ifcfg_backup
+    {%- endif %}
 {%- endif %}
 
 {%- if startmode_ifcfg['auto'] or startmode_ifcfg['off'] %}
@@ -150,6 +152,8 @@ network_wicked_interfaces:
       {%- endfor %}
     - require:
       - file: network_wicked_script
+      {%- if interface_files %}
       - file: network_wicked_ifcfg_backup
+      {%- endif %}
       - file: network_wicked_ifcfg_settings
 {%- endif %}

--- a/network-formula/network/wicked/routes.sls
+++ b/network-formula/network/wicked/routes.sls
@@ -24,11 +24,14 @@ include:
 
 {%- set file = base ~ '/routes' %}
 {%- if salt['file.file_exists'](file) %}
+{%- set backup = True %}
 network_wicked_routes_backup:
   file.copy:
     - names:
       - {{ base_backup }}/routes:
         - source: {{ file }}
+{%- else %}
+{%- set backup = False %}
 {%- endif %}
 
 {%- if routes %}
@@ -60,7 +63,9 @@ network_wicked_routes_reload:
     - require:
       - file: network_wicked_script
       - file: network_wicked_script_links
-      - file: network_wicked_ifcfg_backup
+      {%- if backup %}
+      - file: network_wicked_routes_backup
+      {%- endif %}
       - file: network_wicked_ifcfg_settings
     - onchanges:
       - file: network_wicked_routes


### PR DESCRIPTION
If the file backup state is skipped due to no source files, skip the requisites in subsequent states as well.

Follow-up to eb668b37690112b5855a320f57faafa60fb1e1c1.