### PR TITLE
Support network apply to be skipped

### DIFF
--- a/network-formula/network/map.jinja
+++ b/network-formula/network/map.jinja
@@ -21,5 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- set config = network.get('config', {}) %}
 {%- set routes = network.get('routes', {}) -%}
 {%- set interfaces = network.get('interfaces', {}) -%}
+{%- set control = network.get('control', {}) -%}
+{%- set do_apply = control.get('apply', True) -%}
 
 {%- set legal_backends = ['wicked'] -%}

--- a/network-formula/network/wicked/interfaces.sls
+++ b/network-formula/network/wicked/interfaces.sls
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -#}
 
-{%- from 'network/wicked/map.jinja' import base, base_backup, interfaces, script -%}
+{%- from 'network/wicked/map.jinja' import base, base_backup, interfaces, script, do_apply -%}
 {%- set ifcfg_data = {} %}
 {%- set enslaved = [] %}
 {%- set startmode_ifcfg = {'auto': [], 'off': []} %}
@@ -131,7 +131,7 @@ network_wicked_ifcfg_settings:
     {%- endif %}
 {%- endif %}
 
-{%- if startmode_ifcfg['auto'] or startmode_ifcfg['off'] %}
+{%- if do_apply and ( startmode_ifcfg['auto'] or startmode_ifcfg['off'] ) %}
 network_wicked_interfaces:
   cmd.run:
     - names:

--- a/network-formula/network/wicked/map.jinja
+++ b/network-formula/network/wicked/map.jinja
@@ -16,10 +16,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -#}
 
-{%- from 'network/map.jinja' import config, interfaces, routes -%}
+{%- from 'network/map.jinja' import config, interfaces, routes, do_apply -%}
 {%- set config = config -%}
 {%- set interfaces = interfaces -%}
 {%- set routes = routes -%}
+{%- set do_apply = do_apply -%}
 
 {%- set base = '/etc/sysconfig/network' -%}
 {%- set base_backup = base ~ '/salt-backup' %}

--- a/network-formula/network/wicked/netconfig.sls
+++ b/network-formula/network/wicked/netconfig.sls
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -#}
 
-{%- from 'network/wicked/map.jinja' import base, config -%}
+{%- from 'network/wicked/map.jinja' import base, config, do_apply -%}
 
 network_wicked_config_header:
   file.prepend:
@@ -44,9 +44,11 @@ network_wicked_config:
     - require:
       - file: network_wicked_config_header
 
+{%- if do_apply %}
 network_wicked_netconfig_update:
   cmd.run:
     - name: netconfig update
     - onchanges:
       - file: network_wicked_config
+{%- endif %} {#- close do_apply check #}
 {%- endif %}

--- a/network-formula/network/wicked/routes.sls
+++ b/network-formula/network/wicked/routes.sls
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -#}
 
-{%- from 'network/wicked/map.jinja' import base, base_backup, routes, script -%}
+{%- from 'network/wicked/map.jinja' import base, base_backup, routes, script, do_apply -%}
 
 include:
   - .common
@@ -52,6 +52,7 @@ network_wicked_routes:
       {%- endfor %}
     - mode: '0640'
 
+{%- if do_apply %}
 network_wicked_routes_reload:
   cmd.run:
     - name: {{ script }}routes
@@ -70,4 +71,5 @@ network_wicked_routes_reload:
       - file: network_wicked_ifcfg_settings
     - onchanges:
       - file: network_wicked_routes
+{%- endif %} {#- close do_apply check #}
 {%- endif %}

--- a/network-formula/pillar.example
+++ b/network-formula/pillar.example
@@ -1,4 +1,9 @@
 network:
+  control:
+    # by default, changes will be applied after configuration files have been written
+    # this can be set to False if it's desired for no reload operations to be performed
+    apply: True
+
   # settings written into /etc/sysconfig/network/config
   config:
     # keys/values are written as-is, but keys are uppercased and booleans values are converted automatically.


### PR DESCRIPTION
This adds a network:control:apply pillar setting - if set to False, only configuration files will be written and no reload operations will be performed. This is useful if it's desired for changes to only become live on the next reboot.