### PR TITLE
libvirt: manage libvirt-guests service

### DIFF
--- a/libvirt-formula/libvirt/guests.sls
+++ b/libvirt-formula/libvirt/guests.sls
@@ -1,0 +1,61 @@
+{#-
+Salt state file for managing libvirt-guests
+Copyright (C) 2023 Georg Pfuetzenreuter <mail+opensuse@georg-pfuetzenreuter.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-#}
+
+{%- from 'libvirt/map.jinja' import config -%}
+
+{%- set options = config.get('guests', {}) %}
+
+{%- if 'enable' in options %}
+{%- set enable = options.pop('enable') %}
+{%- else %}
+{%- set enable = True %}
+{%- endif %}
+
+{%- if options %}
+libvirt_guests_sysconfig_file:
+  file.managed:
+    - name: /etc/sysconfig/libvirt-guests
+    - replace: false
+
+libvirt_guests_sysconfig:
+  file.keyvalue:
+    - name: /etc/sysconfig/libvirt-guests
+    - key_values:
+        {%- for key, value in options.items() %}
+        {{ key | upper }}: {{ value }}
+        {%- endfor %}
+    - append_if_not_found: true
+    - ignore_if_missing: {{ opts['test'] }}
+    - require:
+      - file: libvirt_guests_sysconfig_file
+{%- endif %}
+
+libvirt_guests_service:
+{%- if enable %}
+  service.running:
+    - name: libvirt-guests
+    - enable: true
+    {%- if options %}
+    - require:
+      - file: libvirt_guests_sysconfig
+    {%- endif %}
+{%- else %}
+  service.dead:
+    - name: libvirt-guests
+    - enable: false
+{%- endif %}

--- a/libvirt-formula/pillar.example
+++ b/libvirt-formula/pillar.example
@@ -24,3 +24,13 @@ libvirt:
     tcp: true
     # admin -> libvirtd-admin.socket, ro -> libvirtd-ro.socket
     # libvirtd -> libvirtd.socket (will not get 'libvirtd-' prepended, unlike the other examples)
+
+  # contrary the examples above, the following does not reflect the formula defaults.
+  # everything under "guests" will be set in /etc/sysconfig/libvirt-guests - except for "enable", which defines whether the service should be enabled.
+  guests:
+    # "enable" is true by default - set to "false" if libvirt-guests should be disabled
+    enable: true
+    on_boot: ignore
+    on_shutdown: shutdown
+    parallel_shutdown: 2
+    start_delay: 5


### PR DESCRIPTION
Introduce "libvirt:guests" pillar for configuring
/etc/sysconfig-libvirt-guests and the respective libvirt-guests service.