### PR TITLE
Handle rebootmgr with no pillar

### DIFF
--- a/rebootmgr-formula/rebootmgr/init.sls
+++ b/rebootmgr-formula/rebootmgr/init.sls
@@ -58,7 +58,9 @@ rebootmgr_service:
   service.running:
     - name: rebootmgr
     - enable: {{ config.get('enable', True) }}
+    {%- if 'rebootmgr' in pillar %}
     - watch:
       - file: rebootmgr_config
+    {%- endif %}
     - require:
       - pkg: rebootmgr_package


### PR DESCRIPTION
Mitigate service state failure if configuration state was not rendered due to the rebootmgr pillar not existing.