### PR TITLE
Remove chrony from suse_ha packages

### DIFF
--- a/suse_ha-formula/suse_ha/packages.sls
+++ b/suse_ha-formula/suse_ha/packages.sls
@@ -21,7 +21,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 suse_ha_packages:
   pkg.installed:
     - pkgs:
-      - chrony
       - conntrack-tools
       - corosync
       - crmsh


### PR DESCRIPTION
This caused a duplication error if downstream Salt repositories want to use
package aggregation but include other means of installing chrony, for example
the "chrony" formula state in addition to suse_ha.packages.