### PR TITLE
Add virtlockd to default os-update restart excludes

### DIFF
--- a/os_update-formula/os-update/map.jinja
+++ b/os_update-formula/os-update/map.jinja
@@ -29,6 +29,7 @@ reboot_cmd: auto
 restart_services: 'yes'
 ignore_services_from_restart:
   - dbus
+  - virtlockd
 services_triggering_reboot:
   - dbus
 {%- endload -%}

--- a/os_update-formula/pillar.example
+++ b/os_update-formula/pillar.example
@@ -14,5 +14,6 @@ os-update:
   restart_services: 'yes'
   ignore_services_from_restart:
     - dbus
+    - virtlockd
   services_triggering_reboot:
     - dbus


### PR DESCRIPTION
Update to upstream commit:
openSUSE/os-update.git 5f9202fb36f8948e5068363c4abd9d8af3ee860b

Introduced in https://github.com/openSUSE/os-update/pull/17.