### PR TITLE
Remove ifcfg requirement from routes

### DIFF
--- a/network-formula/network/wicked/routes.sls
+++ b/network-formula/network/wicked/routes.sls
@@ -68,7 +68,6 @@ network_wicked_routes_reload:
       {%- if backup %}
       - file: network_wicked_routes_backup
       {%- endif %}
-      - file: network_wicked_ifcfg_settings
     - onchanges:
       - file: network_wicked_routes
 {%- endif %} {#- close do_apply check #}


### PR DESCRIPTION
Allow network.wicked.routes to be applied without accompanying interface/ifcfg configurations.