### PR TITLE
infrastructure.salt: set script permissions

### DIFF
--- a/infrastructure-formula/infrastructure/salt/proxy_networkautomation.sls
+++ b/infrastructure-formula/infrastructure/salt/proxy_networkautomation.sls
@@ -133,6 +133,7 @@ salt_proxy_scripts:
   file.managed:
     - name: /usr/local/sbin/reset-proxy-containers.sh
     - source: salt://{{ slspath }}/files/usr/local/sbin/reset-proxy-containers.sh
+    - mode: '0750'
 
 {%- else %}
 salt_proxy_nw_autom_fail:


### PR DESCRIPTION
Container reset script needs to be executable by root.