### PR TITLE
juniper_junos: drop mc option truthiness check

### DIFF
--- a/juniper_junos-formula/juniper_junos/files/interfaces.j2
+++ b/juniper_junos-formula/juniper_junos/files/interfaces.j2
@@ -106,7 +106,7 @@ delete interfaces {{ interface }}
 {%- set mclo = ['mc-ae-id', 'redundancy-group', 'chassis-id', 'status-control', 'init-delay-time'] -%}
 
 {%- for option in mclo %}
-{%- if option in mclc and mclc[option] %}
+{%- if option in mclc %}
 {{ setifaemc }} {{ option }} {{ mclc[option] }}
 {%- endif %}
 {%- endfor %}


### PR DESCRIPTION
The truthiness conditional caused data containing falsy integers, such as "chassis-id: 0", to be wrongfully ignored. Since the mc dict should only contain integers and strings which do not benefit from the additional condition, it is removed.