### PR TITLE
kexec: repair conditional execution

### DIFF
--- a/kexec-formula/kexec/init.sls
+++ b/kexec-formula/kexec/init.sls
@@ -27,9 +27,12 @@ kexec_service_enable:
         - pkg: kexec_package
 
 kexec_service_run:
-  service.running:
-    - name: kexec-load
-    - unless: kexec -S
+  module.run:
+    - name: service.start
+    - m_name: kexec-load
+    - unless:
+        - fun: sysfs.read
+          key: kernel/kexec_loaded
     - require:
         - pkg: kexec_package
         - service: kexec_service_enable


### PR DESCRIPTION
The "kexec -S" call checks "kexec_crash_loaded", which is only relevant for Kdump. In this case we are interested in "kexec_loaded". Additionally, replace the service state with a service module call, since the service.running state function tends to fail with oneshot services, not being able to detect them alive after execution.