### PR TITLE
juniper_junos: define ignore variable fallback

### DIFF
--- a/juniper_junos-formula/juniper_junos/files/interfaces.j2
+++ b/juniper_junos-formula/juniper_junos/files/interfaces.j2
@@ -1,9 +1,8 @@
 {#- FIXME: move these to context variables #}
 {%- set interfaces = salt['pillar.get']('juniper_junos:interfaces') -%}
-{%- set ignore = salt['pillar.get']('juniper_junos:ignore') -%}
 {%- set present_interfaces = salt['susejunos.get_active_interfaces']() -%}
 
-{%- set ignored_interfaces = ignore.get('interfaces', []) -%}
+{%- set ignored_interfaces = salt['pillar.get']('juniper_junos:ignore', {}).get('interfaces', []) -%}
 {%- set reth_ns = namespace(count=0) %}
 
 {%- for interface in present_interfaces %}

--- a/juniper_junos-formula/juniper_junos/files/vlans.j2
+++ b/juniper_junos-formula/juniper_junos/files/vlans.j2
@@ -1,9 +1,8 @@
 {#- FIXME: move these to context variables #}
 {%- set vlans = salt['pillar.get']('juniper_junos:vlans') -%}
-{%- set ignore = salt['pillar.get']('juniper_junos:ignore') -%}
 {%- set present_vlans = salt['susejunos.get_active_vlans']() -%}
 
-{%- set ignore_vlans = ignore.get('vlans', {}) %}
+{%- set ignore_vlans = salt['pillar.get']('juniper_junos:ignore', {}).get('vlans', {}) %}
 {%- set ignore_vlan_ids = ignore_vlans.get('ids', []) %}
 {%- set ignore_vlan_names = ignore_vlans.get('names', []) %}
 


### PR DESCRIPTION
- set default value to an empty dict in order for get() to not fail if no ignores are found in the pillar
- slightly simplify code by merging two lines