### PR TITLE
rebootmgr: repair configuration for Tumbleweed

### DIFF
--- a/rebootmgr-formula/rebootmgr/init.sls
+++ b/rebootmgr-formula/rebootmgr/init.sls
@@ -23,38 +23,20 @@ rebootmgr_package:
     - name: rebootmgr
 
 {%- if 'rebootmgr' in pillar %}
-{%- if os == 'openSUSE Tumbleweed' %}
-rebootmgr_config_file:
+rebootmgr_config:
   file.managed:
     - name: /etc/rebootmgr.conf
-    - replace: false
-{%- endif %}
-
-rebootmgr_config_header:
-  file.prepend:
-    - name: /etc/rebootmgr.conf
-    - text: {{ pillar.get('managed_by_salt_formula', '# Managed by the rebootmgr formula') | yaml_encode }}
-
-rebootmgr_config:
-  file.keyvalue:
-    - name: /etc/rebootmgr.conf
-    - key_values:
+    - contents:
+        - {{ pillar.get('managed_by_salt_formula', '# Managed by the rebootmgr formula') | yaml_encode }}
+        - '[rebootmgr]'
         {%- for option in options %}
-        {{ option }}: '"{{ config[option] }}"'
+        - '{{ option }}="{{ config[option] }}"'
         {%- endfor %}
-    - ignore_if_missing: {{ opts['test'] }}
-    {%- if os == 'openSUSE Tumbleweed' %}
-    - append_if_not_found: true
-    {%- endif %}
     - require:
-      {%- if os == 'openSUSE Tumbleweed' %}
-      - file: rebootmgr_config_file
-      {%- else %}
       - pkg: rebootmgr_package
-      {%- endif %}
 
 {%- elif os == 'openSUSE Tumbleweed' %}
-rebootmgr_config_file:
+rebootmgr_config:
   file.absent:
     - name: /etc/rebootmgr.conf
 {%- endif %}


### PR DESCRIPTION
On Tumbleweed systems the configuration file placed using the formula
code was missing the "[rebootmgr]" header, causing options to be ignored.
This issue only affects Tumbleweed, where no /etc/rebootmgr.conf file
is provided by the package in favor of the one in /usr/etc. On Leap,
the package provides the file under /etc including the necessary section
header.
To resolve this problemtic discrepancy as well as to simplify the logic,
this refactors the handling to a simple file.managed state containing both
the common and the section header along with the configuration options.
This will ensure a uniform and functional file across both Leap and
Tumbleweed systems.