### PR TITLE
infrastructure: fetch cluster from pillar

### DIFF
--- a/infrastructure-formula/infrastructure/libvirt/domains.sls
+++ b/infrastructure-formula/infrastructure/libvirt/domains.sls
@@ -26,7 +26,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- else -%}
 {%- do salt.log.debug('libvirt.domains: running non-orchestrated') -%}
 {%- set domain = grains['domain'] -%}
+{%- if 'virt_cluster' in grains %}
 {%- set cluster = grains['virt_cluster'].replace('-bare','') -%}
+{%- else %}
+{%- set cluster = pillar.get('cluster') %}
+{%- endif %}
 {%- set lowpillar = salt['pillar.get']('infrastructure') -%}
 {%- endif -%} {#- close do_vd check -#}
 {%- if not 'domains' in lowpillar -%}

--- a/infrastructure-formula/infrastructure/suse_ha/resources.sls
+++ b/infrastructure-formula/infrastructure/suse_ha/resources.sls
@@ -30,7 +30,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- set domain = grains['domain'] -%}
 {%- endif %}
 {%- set myid = grains['id'] -%}
+{%- if 'virt_cluster' in grains %}
 {%- set cluster = grains['virt_cluster'].replace('-bare','') -%}
+{%- else %}
+{%- set cluster = pillar.get('cluster') %}
+{%- endif %}
 {%- if not 'domains' in lowpillar -%}
 {%- do salt.log.error('Incomplete orchestration pillar - verify whether the orchestrator role is assigned.') -%}
 {%- elif not domain in lowpillar['domains'] -%}


### PR DESCRIPTION
In the openSUSE infrastructure we introduced a "cluster" pillar key indicating the minions cluster membership. Avoid the need for a redundant "virt_cluster" grain.