### PR TITLE
suse_ha: remove ctdb from packages

### DIFF
--- a/suse_ha-formula/suse_ha/packages.sls
+++ b/suse_ha-formula/suse_ha/packages.sls
@@ -24,7 +24,6 @@ suse_ha_packages:
       - conntrack-tools
       - corosync
       - crmsh
-      - ctdb
       - fence-agents
       - ldirectord
       - pacemaker


### PR DESCRIPTION
Only needed for SAMBA clustering, which we do not use. Removing it from the package list allows for keeping SAMBA libraries off SUSE HA hosts.