### PR TITLE
mtail: add dependency on sysconfig formula

### DIFF
--- a/mtail-formula/metadata/metadata.yml
+++ b/mtail-formula/metadata/metadata.yml
@@ -1,3 +1,5 @@
 ---
 summary:
   Salt states for managing mtail
+require:
+  - sysconfig


### PR DESCRIPTION
Uses suse_sysconfig states, hence ensure sysconfig-formula is installed as a dependency.