### PR TITLE
Switch network sysconfig header state

### DIFF
--- a/network-formula/metadata/metadata.yml
+++ b/network-formula/metadata/metadata.yml
@@ -3,3 +3,5 @@ summary:
   Salt states for managing the network
 description:
   Salt states for managing the network configuration using backends like Wicked.
+require:
+  - sysconfig

--- a/network-formula/network/wicked/netconfig.sls
+++ b/network-formula/network/wicked/netconfig.sls
@@ -19,9 +19,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- from 'network/wicked/map.jinja' import base, config, do_apply -%}
 
 network_wicked_config_header:
-  file.prepend:
+  suse_sysconfig.header:
     - name: {{ base }}/config
-    - text: {{ pillar.get('managed_by_salt_formula', '# Managed by the network formula') | yaml_encode }}
+    - fillup: config-network
+    - header_pillar: managed_by_salt_formula_sysconfig
 
 {%- if config %}
 network_wicked_config:


### PR DESCRIPTION
Switch to common suse_sysconfig.header function to unify the code and to restore idempotence by avoiding header changes on package updates.