### PR TITLE
Repair error on initial network.wicked execution

### DIFF
--- a/network-formula/network/wicked/interfaces.sls
+++ b/network-formula/network/wicked/interfaces.sls
@@ -138,7 +138,13 @@ network_wicked_interfaces:
       {%- for interface in startmode_ifcfg['auto'] %}
       - {{ script }}up {{ interface }}:
         - stateful:
-          - test_name: {{ script }}up {{ interface }} test
+          - test_name: |
+              if test -x {{ script }}up
+              then
+                {{ script }}up {{ interface }} test
+              else
+                echo 'changed=True comment="Helper script is not available" result=None'
+              fi
         {%- if salt['cmd.retcode'](cmd='ifstatus ' ~ interface ~ ' -o quiet', ignore_retcode=True) == 0 %}
         - onchanges:
           - file: {{ base }}/ifcfg-{{ interface }}
@@ -156,4 +162,5 @@ network_wicked_interfaces:
       - file: network_wicked_ifcfg_backup
       {%- endif %}
       - file: network_wicked_ifcfg_settings
+    - shell: /bin/sh
 {%- endif %}


### PR DESCRIPTION
The interface states rely on a helper script - if the common states have not yet been applied on a minion, an initial test run would return network_wicked_interfaces as failed due to the helper script not being present.
Resolve this by testing whether the script has already been installed, and constructing a graceful return otherwise.