### PR TITLE
juniper_junos: support speed configuration

### DIFF
--- a/juniper_junos-formula/juniper_junos/files/interfaces.j2
+++ b/juniper_junos-formula/juniper_junos/files/interfaces.j2
@@ -25,6 +25,10 @@ delete interfaces {{ interface }}
 {{ setif }} description "{{ ifconfig['description'] }}"
 {%- endif %}
 
+{%- if 'speed' in ifconfig %}
+{{ setif }} speed {{ ifconfig['speed'] | lower }}
+{%- endif %}
+
 {%- if not 'lacp' in ifconfig and not ifname.startswith(('em', 'fxp', 'vme')) %} {#- setting the MTU on a ae children or management interfaces is not allowed #}
 {%- if pillar.get('simulation', False) %}
 {%- set default_mtu = 1500 %}

--- a/juniper_junos-formula/pillar.example.yml
+++ b/juniper_junos-formula/pillar.example.yml
@@ -35,6 +35,7 @@ juniper_junos:
     ge-0/0/2:
       description: foo
       mtu: 9100
+      speed: 1G
       # "native_vlan" cannot be combined with vlan:access, only with vlan:trunk
       native_vlan: 2
       units:

--- a/juniper_junos-formula/tests/pillar.sls
+++ b/juniper_junos-formula/tests/pillar.sls
@@ -39,6 +39,7 @@ juniper_junos:
     # reth* interfaces will be counted to set the reth-count
     ge-0/0/2:
       description: foo
+      speed: 1G
       mtu: 9100
       #reth: reth0
       # cannot be combined with vlan:access, only vlan:trunk

--- a/juniper_junos-formula/tests/test_120_states.py
+++ b/juniper_junos-formula/tests/test_120_states.py
@@ -98,6 +98,7 @@ def test_apply(host, device, state, test):
     diffs_shared = [
             '+   ge-0/0/2 {',
             '+       description foo;',
+            '+       speed 1g;',
             '+       mtu 9100;',
             '+       unit 0 {',
             '+           description bar;',


### PR DESCRIPTION
This allows the interface speed setting to be set through the pillar.