### PR TITLE
infrastructure.salt: handle Git

### DIFF
--- a/infrastructure-formula/infrastructure/salt/git/formulas.sls
+++ b/infrastructure-formula/infrastructure/salt/git/formulas.sls
@@ -1,0 +1,21 @@
+{%- from 'infrastructure/salt/map.jinja' import git, formulas -%}
+
+{%- if 'repository' in formulas %}
+{%- set branch = formulas.get('branch', git.branch) %}
+
+salt_formula_clone:
+  git.latest:
+    - name: {{ formulas['repository'] }}
+    - target: {{ formulas.directory }}
+    - branch: {{ branch }}
+    - rev: {{ branch }}
+    {#- test apply fails if the user does not yet exist #}
+    {%- if not opts['test'] or salt['user.info'](git.user) %}
+    - user: {{ git.user }}
+    {%- endif %}
+    - force_checkout: true
+    - force_clone: true
+    - force_reset: true
+    - fetch_tags: false
+    - submodules: true
+{%- endif %}

--- a/infrastructure-formula/infrastructure/salt/git/init.sls
+++ b/infrastructure-formula/infrastructure/salt/git/init.sls
@@ -1,0 +1,40 @@
+{%- from 'infrastructure/salt/map.jinja' import git, formulas -%}
+
+salt_git_user:
+  user.present:
+    - name: {{ git.user }}
+    - usergroup: false
+    - fullname: Git Cloney
+    - system: true
+    - home: /var/lib/{{ git.user }}
+    - createhome: false
+    - shell: /sbin/nologin
+
+salt_git_directory:
+  file.directory:
+    - names:
+        - {{ git.directory }}
+        {%- if 'repository' in formulas %}
+        - {{ formulas.directory }}
+        {%- endif %}
+    - user: {{ git.user }}
+    - group: salt
+    - require:
+        - user: salt_git_user
+    {%- if 'repository' in formulas %}
+    - require_in:
+        - git: salt_formula_clone
+    {%- endif %}
+
+{%- for l in ['salt', 'pillar'] %}
+salt_git_link_{{ l }}:
+  file.symlink:
+    - name: /srv/{{ l }}
+    - target: {{ git.directory }}/{{ l }}
+    - force: true
+    - require:
+        - file: salt_git_directory
+{%- endfor %}
+
+include:
+  - .formulas

--- a/infrastructure-formula/infrastructure/salt/map.jinja
+++ b/infrastructure-formula/infrastructure/salt/map.jinja
@@ -1,0 +1,30 @@
+{#-
+Jinja variables file for the infrastructure.salt formula
+Copyright (C) 2024 Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-#}
+
+{%- load_yaml as defaults -%}
+git:
+  branch: production
+  user: cloneboy
+  directory: /srv/salt-git
+  formulas:
+    directory: /srv/formulas
+{%- endload -%}
+
+{%- set config  = salt.pillar.get('infrastructure:salt', default=defaults, merge=True, merge_nested_lists=False) -%}
+{%- set git = config.get('git', {}) -%}
+{%- set formulas = git.get('formulas', {}) -%}

--- a/infrastructure-formula/pillar.example.yml
+++ b/infrastructure-formula/pillar.example.yml
@@ -45,4 +45,15 @@ infrastructure:
           # reference to a file or symlink in $kvm_topdir/os-images.
           image: example.raw
 
+  salt:
+    git:
+      # default user and directory
+      user: cloneboy
+      directory: /srv/salt-git
+      formulas:
+        # default directory
+        directory: /srv/formulas
+        # example repository (no formulas will be cloned unless defined in the pillar)
+        repository: https://code.opensuse.org/heroes/salt-formulas-git.git
+
 # *RT: attribute is only used for updating RackTables


### PR DESCRIPTION
The Git repository logic from openSUSE
infra/salt.git/salt/profile/salt/git was found to be useful to have
as a formula - import it, along with extending it with pillar based
configuration and a patch for ensuring an initial test apply does
not fail if the clone user does not yet exist.