### PR TITLE
network: repair header placement

### DIFF
--- a/network-formula/network/wicked/netconfig.sls
+++ b/network-formula/network/wicked/netconfig.sls
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 network_wicked_config_header:
   suse_sysconfig.header:
     - name: {{ base }}/config
-    - fillup: config-network
+    - fillup: config-wicked
     - header_pillar: managed_by_salt_formula_sysconfig
 
 {%- if config %}


### PR DESCRIPTION
The /etc/sysconfig/network/config file is comprised of two fillup templates:
sysconfig.config-network
sysconfig.config-wicked
The first line is defined by config-wicked, hence use this instead of config-network as a reference template to repair the header being placed at the beginning instead of in the middle of the sysconfig file.