### PR TITLE
sysconfig: convert booleans and handle quoting

### DIFF
--- a/sysconfig-formula/_states/suse_sysconfig.py
+++ b/sysconfig-formula/_states/suse_sysconfig.py
@@ -36,17 +36,23 @@ def header(name, fillup=None, header_pillar=None):
     repl=patterns['replace'],
   )
 
-def sysconfig(name, key_values, fillup=None, header_pillar=None, upper=True, append_if_not_found=False):
+def sysconfig(name, key_values, fillup=None, header_pillar=None, unbool=True, upper=True, append_if_not_found=False):
   """
   Manages both the header and the key/value pairs in a sysconfig file.
   name = sysconfig file to manage (relative paths will be appended to /etc/sysconfig/)
+  unbool = whether boolean keys should be converted to quoted yes/no strings
   upper = whether keys should be converted to upper case
   All other arguments are passed to the equally named arguments in the suse_sysconfig.header and file.keyvalue functions.
   """
   if not name.startswith('/'):
     name = f'/etc/sysconfig/{name}'
-  if upper:
-    key_values = {key.upper(): value for key, value in key_values.items()}
+  boolmap = {
+    True: '"yes"',
+    False: '"no"',
+  }
+  key_values = {
+    key.upper() if upper else key: boolmap[value] if unbool and isinstance(value, bool) else value for key, value in key_values.items()
+  }
   returns = {
     'header': __states__['suse_sysconfig.header'](
                 name=name,

--- a/sysconfig-formula/_states/suse_sysconfig.py
+++ b/sysconfig-formula/_states/suse_sysconfig.py
@@ -36,23 +36,48 @@ def header(name, fillup=None, header_pillar=None):
     repl=patterns['replace'],
   )
 
-def sysconfig(name, key_values, fillup=None, header_pillar=None, unbool=True, upper=True, append_if_not_found=False):
+def sysconfig(name, key_values, fillup=None, header_pillar=None, quote=True, quote_char='"', quote_booleans=True, quote_integers=False, quote_strings=True, unbool=True, upper=True, append_if_not_found=False):
   """
   Manages both the header and the key/value pairs in a sysconfig file.
   name = sysconfig file to manage (relative paths will be appended to /etc/sysconfig/)
-  unbool = whether boolean keys should be converted to quoted yes/no strings
+  quote = whether to quote values
+  quote_char = the character to quote values with
+  quote_booleans = whether to quote boolean values - ignored if quote=False
+  quote_integers = whether to quote integer values - ignored if quote=False
+  quote_strings = whether to quote string values - ignored if quote=False
+  unbool = whether boolean values should be converted to yes/no strings
   upper = whether keys should be converted to upper case
   All other arguments are passed to the equally named arguments in the suse_sysconfig.header and file.keyvalue functions.
   """
   if not name.startswith('/'):
     name = f'/etc/sysconfig/{name}'
+
   boolmap = {
-    True: '"yes"',
-    False: '"no"',
+    True: 'yes',
+    False: 'no',
   }
-  key_values = {
-    key.upper() if upper else key: boolmap[value] if unbool and isinstance(value, bool) else value for key, value in key_values.items()
-  }
+  boolmap_values = boolmap.values()
+
+  _key_values = {}
+  for key, value in key_values.items():
+    if upper:
+      key = key.upper()
+    if unbool and isinstance(value, bool):
+      value = boolmap[value]
+    if quote and not value.startswith(quote_char) and (
+      quote_strings and isinstance(value, str) and value not in boolmap_values
+      or
+      quote_booleans and value in boolmap_values
+      or
+      quote_integers and isinstance(value, int)
+    ):
+      value = f'{quote_char}{value}{quote_char}'
+    _key_values.update(
+      {
+        key: value,
+      },
+    )
+
   returns = {
     'header': __states__['suse_sysconfig.header'](
                 name=name,
@@ -63,7 +88,7 @@ def sysconfig(name, key_values, fillup=None, header_pillar=None, unbool=True, up
                 name=name,
                 append_if_not_found=append_if_not_found,
                 ignore_if_missing=__opts__['test'],
-                key_values=key_values,
+                key_values=_key_values,
               ),
   }
 


### PR DESCRIPTION
Patch 1:

In sysconfig files booleans are usually interpreted as yes/no values. Handle this in the state by default to avoid stringifying booleans in the pillar.

Patch 2:

Avoid reptitive quoting handling in states using this function and
cover the common quoting style by default, whilst allowing overrides
for fillup templates using a different one.