### PR TITLE
apache_httpd: align string option indentation

### DIFF
--- a/apache_httpd-formula/apache_httpd/templates/config.jinja
+++ b/apache_httpd-formula/apache_httpd/templates/config.jinja
@@ -60,7 +60,7 @@
 {{ ( '</' ~ option ~ '>' ) | indent(i, True) }}
 
       {%- elif low_value is string %}
-    {{ option }} {{ low_option }} {{ low_value }}
+{{ ( option ~ ' ' ~ low_option ~ ' ' ~ low_value ) | indent(i, True) }}
 
       {%- endif %} {#- close low_value type check #}
 


### PR DESCRIPTION
Avoid offset if used outside of a vhost block.