### PR TITLE
apache_httpd: add repetitive mod_rewrite options

### DIFF
--- a/apache_httpd-formula/apache_httpd/defaults.json
+++ b/apache_httpd-formula/apache_httpd/defaults.json
@@ -19,7 +19,10 @@
 	"internal": {
 		"repetitive_options": [
 			"Alias",
-			"RemoteIPTrustedProxy"
+			"RemoteIPTrustedProxy",
+			"RewriteCond",
+			"RewriteMap",
+			"RewriteRule"
 		]
 	}
 }


### PR DESCRIPTION
Add support for all options in the rewrite module which take multiple values using multiple declarations.