### PR TITLE
apache_httpd: allow independent places

### DIFF
--- a/apache_httpd-formula/apache_httpd/init.sls
+++ b/apache_httpd-formula/apache_httpd/init.sls
@@ -58,7 +58,9 @@ apache_httpd_load_module-{{ module }}:
         - pkg: apache_httpd_packages
     - require_in:
         {%- for place in places %}
+        {%- if httpd.get(place) %}
         - file: apache_httpd_{{ place }}
+        {%- endif %}
         {%- endfor %}
     - unless:
         - fun: apache.check_mod_enabled
@@ -76,7 +78,9 @@ apache_httpd_unload_module-{{ module }}:
         - mod: {{ module }}
     - require_in:
         {%- for place in places %}
+        {%- if httpd.get(place) %}
         - file: apache_httpd_{{ place }}
+        {%- endif %}
         {%- endfor %}
     {{ watch_in_restart() }}
   {%- endif %}

--- a/apache_httpd-formula/apache_httpd/purge.sls
+++ b/apache_httpd-formula/apache_httpd/purge.sls
@@ -23,6 +23,7 @@ include:
 
 {%- for place in places %}
   {%- set directory = httpd.directories[place] %}
+  {%- set config_pillar = httpd.get(place, {}) %}
   {%- for file in salt['file.find'](directory, print='name', type='f') %}
     {%- set path = directory ~ '/' ~ file %}
     {%- do salt.log.debug('apache_httpd.purge: ' ~ path) %}
@@ -30,7 +31,7 @@ include:
     {%- if
           salt['cmd.retcode']('/usr/bin/rpm -fq --quiet ' ~ path, **cmd_kwargs) == 1
           and
-          file.replace('.conf', '') not in httpd.get(place, {})
+          file.replace('.conf', '') not in config_pillar
     %}
 apache_httpd_remove_{{ place }}-{{ file }}:
   file.absent:


### PR DESCRIPTION
Allow "configs" without "vhosts" and "vhosts" without "configs" instead of always requiring both to be provided in the pillar.

Additionally, make the purges state slightly more efficient by fetching the config only once.