### PR TITLE
apache_httpd: add mod_rewrite module mappings

### DIFF
--- a/apache_httpd-formula/apache_httpd/modules/map.json
+++ b/apache_httpd-formula/apache_httpd/modules/map.json
@@ -5,6 +5,10 @@
 	"RemoteIPTrustedProxy": "remoteip",
 	"RequestHeader": "headers",
 	"RewriteCond": "rewrite",
+	"RewriteEngine": "rewrite",
+	"RewriteMap": "rewrite",
+	"RewriteOptions": "rewrite",
+	"RewriteRule": "rewrite",
 	"SSLCertificateFile": "ssl",
 	"SetEnv": "env"
 }


### PR DESCRIPTION
This adds the remaining vhost options from mod_rewrite to the modules map to ensure all are equally automatically enabling the module.