### PR TITLE
apache_httpd: repetitive options as mappings

### DIFF
--- a/apache_httpd-formula/apache_httpd/defaults.json
+++ b/apache_httpd-formula/apache_httpd/defaults.json
@@ -22,7 +22,8 @@
 			"RemoteIPTrustedProxy",
 			"RewriteCond",
 			"RewriteMap",
-			"RewriteRule"
+			"RewriteRule",
+			"SetEnvIf"
 		]
 	}
 }

--- a/apache_httpd-formula/apache_httpd/templates/config.jinja
+++ b/apache_httpd-formula/apache_httpd/templates/config.jinja
@@ -50,14 +50,24 @@
     {%- for low_option, low_value in value.items() %}
 
       {%- if low_value is mapping %}
+        {%- if option not in repetitive_options %}
 {{ ( '<' ~ option ~ ' "' ~ low_option ~ '">' ) | indent(i, True) }}
-        {%- for low_low_option, low_low_value in low_value.items() %}
-          {%- if low_low_value is string %}
-            {%- set low_low_value = [low_low_value] %}
+        {%- endif %} {#- close first inner repetitive_option check #}
+        {%- for low_low_option, low_low_values in low_value.items() %}
+          {%- if low_low_values is string %}
+            {%- set low_low_values = [low_low_values] %}
           {%- endif %}
-  {{ ( low_low_option ~ ' ' ~ ' '.join(low_low_value) ) | indent(i + 2, True) }}
+          {%- if option in repetitive_options %}
+            {%- for low_low_value in low_low_values %}
+{{ ( option ~ ' ' ~ low_option ~ ' ' ~ low_low_option ~ ' ' ~ low_low_value ) | indent(i, True) }}
+            {%- endfor %}
+          {%- else %}
+  {{ ( low_low_option ~ ' ' ~ ' '.join(low_low_values) ) | indent(i + 2, True) }}
+          {%- endif %} {#- close second inner repetitive_option check #}
         {%- endfor %} {#- close low_value iteration #}
+        {%- if option not in repetitive_options %}
 {{ ( '</' ~ option ~ '>' ) | indent(i, True) }}
+        {%- endif %} {#- close third inner repetitive_option check #}
 
       {%- elif low_value is string %}
 {{ ( option ~ ' ' ~ low_option ~ ' ' ~ low_value ) | indent(i, True) }}

--- a/apache_httpd-formula/pillar.example
+++ b/apache_httpd-formula/pillar.example
@@ -84,6 +84,11 @@ apache_httpd:
             - Indexes
           Require: all granted
 
+      # options which aren't blocks but which take multiple arguments can be provided as mappings as well
+      SetEnvIf:
+        Request_URI:
+          ^/example$: myvariable
+
       # special options used by the formula but not written
       LogFormat: combined
 

--- a/apache_httpd-formula/tests/pillar.sls
+++ b/apache_httpd-formula/tests/pillar.sls
@@ -4,6 +4,10 @@ apache_httpd:
   sysconfig:
     apache_servername: ipv6-localhost
   configs:
+    log:
+      SetEnvIf:
+        Request_URI:
+          ^/health$: donotlog
     remote:
       RemoteIPHeader: X-Forwarded-For
       RemoteIPTrustedProxy:

--- a/apache_httpd-formula/tests/reference/etc/apache2/conf.d/log.conf
+++ b/apache_httpd-formula/tests/reference/etc/apache2/conf.d/log.conf
@@ -1,0 +1,2 @@
+# Managed by the apache_httpd formula
+SetEnvIf Request_URI ^/health$ donotlog

--- a/apache_httpd-formula/tests/reference/etc/apache2/conf.d/log.conf.md5
+++ b/apache_httpd-formula/tests/reference/etc/apache2/conf.d/log.conf.md5
@@ -1,0 +1,1 @@
+f36f2adb9df5b321b6b2383a339de780  log.conf

--- a/apache_httpd-formula/tests/test_httpd.py
+++ b/apache_httpd-formula/tests/test_httpd.py
@@ -52,6 +52,7 @@ def test_httpd_config(host, salt_apply, test):
   assert len(result) > 0
   output = result[0]
   for file, checksum in {
+    'conf.d/log.conf': 'f36f2adb9df5b321b6b2383a339de780',
     'conf.d/remote.conf': '2d4e69a65a3c77743f8504af4ae2415a',
     'vhosts.d/mysite1.conf': '15edeaf0ea295a192e9aa964b011493f',
     'vhosts.d/mysite2.conf': '60c7cf30c4cf87e6ad7cbab904538b73',


### PR DESCRIPTION
This adds suport for mappings which translate to multiple lines instead of "< ... > ... </ ... >" blocks, extending the existing "repetitive options" logic.
As an initial configuration option to utilize this, "SetEnvIf" is added to the repetitive options.

Previously, it was needed to provide "SetEnvIf" configuration in the following format:

```
  configs:
    example:
      SetEnvIf:
        Request_URI: ^/example$ myvariable
```

With this patch, the following will render the same configuration:

```
  configs:
    example:
      SetEnvIf:
        Request_URI:
          ^/example$: myvariable
```

This allows for a more logical data structure in the pillar, uniform with what is already used for less nested options, making the formula easier to parse and less error prone to use.