### PR TITLE
apache_httpd: install apache2-utils

### DIFF
--- a/apache_httpd-formula/apache_httpd/packages.sls
+++ b/apache_httpd-formula/apache_httpd/packages.sls
@@ -27,3 +27,4 @@ apache_httpd_packages:
         - apache2-mod_{{ module }}
           {%- endif %}
         {%- endfor %}
+        - apache2-utils


### PR DESCRIPTION
Needed for apachectl since Leap 15.6 (no longer required by the main package).