### PR TITLE
suse_ha: quote SBD sysconfig values

### DIFF
--- a/suse_ha-formula/suse_ha/sbd.sls
+++ b/suse_ha-formula/suse_ha/sbd.sls
@@ -73,7 +73,7 @@ sbd_sysconfig:
   suse_sysconfig.sysconfig:
     - name: sbd
     - uncomment: '#'
-    - quote: False
+    - quote_char: "'"
     - key_values:
         SBD_DEVICE: {{ sbd_ns.devices }}
         {%- if sysconfig.get('sbd', False) %}


### PR DESCRIPTION
These are interpreted as shell code, add quoting to repair errors such as:

```
warning: fence_legacy stderr:
[ /etc/sysconfig/sbd: line 8: /dev/disk/by-id/dm-uuid-mpath-xxx: Permission denied ]
```

(thanks, https://suse.slack.com/archives/C02DBCLUAPQ/p1721656104621999)