### PR TITLE
apache_httpd: query pillar inside templates

### DIFF
--- a/apache_httpd-formula/apache_httpd/init.sls
+++ b/apache_httpd-formula/apache_httpd/init.sls
@@ -90,8 +90,6 @@ apache_httpd_unload_module-{{ module }}:
 apache_httpd_listen:
   file.managed:
     - name: {{ httpd.directories['base'] }}/listen.conf
-    - context:
-        config: {{ httpd.get('vhosts', {}) }}
     - source: salt://apache_httpd/templates/listen_config.jinja
     {{ config_file_common() }}
     - require:
@@ -106,11 +104,10 @@ apache_httpd_listen:
 apache_httpd_{{ place }}:
   file.managed:
     - names:
-        {%- for config, settings in config_pillar.items() %}
+        {%- for config in config_pillar.keys() %}
         - {{ directory }}/{{ config }}.conf:
             - context:
                 name: {{ config }}
-                config: {{ settings }}
                 type: {{ place }}
                 repetitive_options: {{ httpd.internal.repetitive_options }}
                 logdir: {{ httpd.directories.logs }}

--- a/apache_httpd-formula/apache_httpd/templates/config.jinja
+++ b/apache_httpd-formula/apache_httpd/templates/config.jinja
@@ -1,4 +1,5 @@
 {{ pillar.get('managed_by_salt_formula', '# Managed by the apache_httpd formula') }}
+{%- set config = salt['pillar.get']('apache_httpd:' ~ type, {}).get(name, {}) %}
 
 {%- if type == 'vhosts' %}
 {%- set i = 4 %}

--- a/apache_httpd-formula/apache_httpd/templates/listen_config.jinja
+++ b/apache_httpd-formula/apache_httpd/templates/listen_config.jinja
@@ -1,4 +1,5 @@
 {{ pillar.get('managed_by_salt_formula', '# Managed by the apache_httpd formula') }}
+{%- set config = salt['pillar.get']('apache_httpd:vhosts', {}) %}
 
 {%- if config %}
   {%- set listeners = [] %}


### PR DESCRIPTION
The "context" approach fails when patterns requiring special escaping, most prominently regular expressions, are attempted to be passed through the pillar, because of the escaping only persisting through the first YAML abstraction (the pillar) and not through the second one (the state file).
To avoid this pitfall, skip the second YAML layer by retrieving the pillar directly in the Jinja templates instead of passing it through "context".