### PR TITLE
apache_httpd: use underscore in default log suffix

### DIFF
--- a/apache_httpd-formula/apache_httpd/templates/config.jinja
+++ b/apache_httpd-formula/apache_httpd/templates/config.jinja
@@ -19,10 +19,10 @@
     ServerName {{ name }}
     {%- endif %}
     {%- if not 'CustomLog' in config %}
-    CustomLog {{ '{0}/{1}-access.log'.format(logdir, name) }} {{ config.get('LogFormat', 'combined') }}
+    CustomLog {{ '{0}/{1}-access_log'.format(logdir, name) }} {{ config.get('LogFormat', 'combined') }}
     {%- endif %}
     {%- if not 'ErrorLog' in config %}
-    ErrorLog {{ '{0}/{1}-error.log'.format(logdir, name) }}
+    ErrorLog {{ '{0}/{1}-error_log'.format(logdir, name) }}
     {%- endif %}
 
 {%- elif type == 'configs' %}

--- a/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite1.conf
+++ b/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite1.conf
@@ -2,8 +2,8 @@
 
 <VirtualHost *:80>
     ServerName mysite1
-    CustomLog /var/log/apache2/mysite1-access.log combined
-    ErrorLog /var/log/apache2/mysite1-error.log
+    CustomLog /var/log/apache2/mysite1-access_log combined
+    ErrorLog /var/log/apache2/mysite1-error_log
     RewriteEngine on
     <Directory "/srv/www/htdocs">
         Require all granted

--- a/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite1.conf.md5
+++ b/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite1.conf.md5
@@ -1,1 +1,1 @@
-fcfb1f1a400281f606f421f4752fca1f  mysite1.conf
+6c271da888aa2a2a27384c852ae96789  mysite1.conf

--- a/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite2.conf
+++ b/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite2.conf
@@ -1,8 +1,8 @@
 # Managed by the apache_httpd formula
 
 <VirtualHost *:80>
-    CustomLog /var/log/apache2/mysite2-access.log combined
-    ErrorLog /var/log/apache2/mysite2-error.log
+    CustomLog /var/log/apache2/mysite2-access_log combined
+    ErrorLog /var/log/apache2/mysite2-error_log
     ServerName mysite2.example.com
     RewriteEngine off
     Protocols h2 http/1.1

--- a/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite2.conf.md5
+++ b/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite2.conf.md5
@@ -1,1 +1,1 @@
-270b7ca645a7596d94365811675c41d2  mysite2.conf
+d0004f7ee286d5402c55fa2f187f0bab  mysite2.conf

--- a/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/status.conf
+++ b/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/status.conf
@@ -2,8 +2,8 @@
 
 <VirtualHost ipv6-localhost:8181>
     ServerName status
-    CustomLog /var/log/apache2/status-access.log combined
-    ErrorLog /var/log/apache2/status-error.log
+    CustomLog /var/log/apache2/status-access_log combined
+    ErrorLog /var/log/apache2/status-error_log
     <Location "/server-status">
         SetHandler server-status
     </Location>

--- a/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/status.conf.md5
+++ b/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/status.conf.md5
@@ -1,1 +1,1 @@
-41228b88bdb6156773b4e26c39c5d9bc  status.conf
+dda3e0dd18b99d5c3525dd1b43e35081  status.conf

--- a/apache_httpd-formula/tests/test_httpd.py
+++ b/apache_httpd-formula/tests/test_httpd.py
@@ -54,9 +54,9 @@ def test_httpd_config(host, salt_apply, test):
   for file, checksum in {
     'conf.d/log.conf': 'f36f2adb9df5b321b6b2383a339de780',
     'conf.d/remote.conf': '2d4e69a65a3c77743f8504af4ae2415a',
-    'vhosts.d/mysite1.conf': 'fcfb1f1a400281f606f421f4752fca1f',
-    'vhosts.d/mysite2.conf': '270b7ca645a7596d94365811675c41d2',
-    'vhosts.d/status.conf': '41228b88bdb6156773b4e26c39c5d9bc',
+    'vhosts.d/mysite1.conf': '6c271da888aa2a2a27384c852ae96789',
+    'vhosts.d/mysite2.conf': 'd0004f7ee286d5402c55fa2f187f0bab',
+    'vhosts.d/status.conf': 'dda3e0dd18b99d5c3525dd1b43e35081',
   }.items():
     if file.startswith('conf.d'):
       place = 'configs'


### PR DESCRIPTION
The logrotate configuration shipped with the apache2 package uses these patterns:
- /var/log/apache2/*-access_log
- /var/log/apache2/*-error_log

Adjust our default log file names to match by replacing the dot with underscore suffixes.