### PR TITLE
apache_httpd: refactor CustomLog handling

### DIFF
--- a/apache_httpd-formula/apache_httpd/templates/config.jinja
+++ b/apache_httpd-formula/apache_httpd/templates/config.jinja
@@ -14,12 +14,35 @@
 {%- set listen = [listen] %}
 {%- endif %}
 
+{%- set defaults = {
+      'customlog': {
+        'location': '{0}/{1}-access_log'.format(logdir, name),
+        'format': 'combined',
+        'env': None,
+      },
+    }
+%}
+
+{%- if 'CustomLog' in config and config['CustomLog'] is mapping %}
+  {%- set customlog = config.pop('CustomLog') %}
+  {%- do salt.log.error(customlog) %}
+  {%- for customlog_option in defaults['customlog'].keys() %}
+    {%- do salt.log.error(customlog_option) %}
+    {%- if not customlog_option in customlog %}
+      {%- do customlog.update({customlog_option: defaults['customlog'][customlog_option]}) %}
+    {%- endif %}
+  {%- endfor %}
+{%- else %}
+  {%- set customlog = defaults['customlog'] %}
+{%- endif %}
+{#- if CustomLog is in config and is not a mapping, assume a full CustomLog line to write as-is #}
+
 <VirtualHost {%- for listener in listen %} {{ listener }}{% endfor -%}>
     {%- if not 'ServerName' in config %}
     ServerName {{ name }}
     {%- endif %}
     {%- if not 'CustomLog' in config %}
-    CustomLog {{ '{0}/{1}-access_log'.format(logdir, name) }} {{ config.get('LogFormat', 'combined') }}
+    CustomLog {{ customlog['location'] }} {{ customlog['format'] }}{{ ' env' ~ customlog['env'] if customlog['env'] else '' }}
     {%- endif %}
     {%- if not 'ErrorLog' in config %}
     ErrorLog {{ '{0}/{1}-error_log'.format(logdir, name) }}

--- a/apache_httpd-formula/pillar.example
+++ b/apache_httpd-formula/pillar.example
@@ -92,12 +92,15 @@ apache_httpd:
       # boolean values are rewritten to on/off
       RewriteEngine: true
 
-      # special options used by the formula but not written
-      LogFormat: combined
-
       # the following options are always written if not specified in the pillar, but the values can be overwritten
-      CustomLog: {{ directories.logs }}/{{ name of vhost }}-access.log {{ LogFormat }}
+      CustomLog: {{ directories.logs }}/{{ name of vhost }}-access.log combined
       ErrorLog: {{ directories.logs }}/{{ name of vhost }}-error.log
+
+      # customize CustomLog parameters
+      CustomLog:
+        location: /somewhere/else/foo.log
+        format: notCombined
+        env: =!baz
 
   # the "internal" section is altering behavior in the formula logic
   #   whilst it is possible to set and overwrite these setting in the pillar, doing so is not commonly tested

--- a/apache_httpd-formula/tests/pillar.sls
+++ b/apache_httpd-formula/tests/pillar.sls
@@ -24,6 +24,8 @@ apache_httpd:
       Directory:
         /srv/www/htdocs:
           Require: all granted
+      CustomLog:
+        env: =!donotlog
     mysite2:
       ServerName: mysite2.example.com
       RewriteEngine: off

--- a/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite1.conf
+++ b/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite1.conf
@@ -2,7 +2,7 @@
 
 <VirtualHost *:80>
     ServerName mysite1
-    CustomLog /var/log/apache2/mysite1-access_log combined
+    CustomLog /var/log/apache2/mysite1-access_log combined env=!donotlog
     ErrorLog /var/log/apache2/mysite1-error_log
     RewriteEngine on
     <Directory "/srv/www/htdocs">

--- a/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite1.conf.md5
+++ b/apache_httpd-formula/tests/reference/etc/apache2/vhosts.d/mysite1.conf.md5
@@ -1,1 +1,1 @@
-6c271da888aa2a2a27384c852ae96789  mysite1.conf
+da428b1d98b77a0679a7cb7f1b981be9  mysite1.conf

--- a/apache_httpd-formula/tests/test_httpd.py
+++ b/apache_httpd-formula/tests/test_httpd.py
@@ -54,7 +54,7 @@ def test_httpd_config(host, salt_apply, test):
   for file, checksum in {
     'conf.d/log.conf': 'f36f2adb9df5b321b6b2383a339de780',
     'conf.d/remote.conf': '2d4e69a65a3c77743f8504af4ae2415a',
-    'vhosts.d/mysite1.conf': '6c271da888aa2a2a27384c852ae96789',
+    'vhosts.d/mysite1.conf': 'da428b1d98b77a0679a7cb7f1b981be9',
     'vhosts.d/mysite2.conf': 'd0004f7ee286d5402c55fa2f187f0bab',
     'vhosts.d/status.conf': 'dda3e0dd18b99d5c3525dd1b43e35081',
   }.items():


### PR DESCRIPTION
- allow the "LogFormat" option to be used for its httpd-native functionality, instead of occupying it as a formula setting
- allow customizing of individual CustomLog parameters in addition to providing a completely custom CustomLog line
- allow adding of an environment parameter to the default CustomLog line