### PR TITLE
infrastructure.salt: add qjid script

### DIFF
--- a/infrastructure-formula/infrastructure/salt/files/usr/local/sbin/qjid
+++ b/infrastructure-formula/infrastructure/salt/files/usr/local/sbin/qjid
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Script to get a Salt job output colored and paged
+# Copyright (C) 2024 Georg Pfuetzenreuter <mail+opensuse@georg-pfuetzenreuter.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+jid="${1?Pass a Salt job ID}"
+salt-run --force-color jobs.lookup_jid "$jid" | less -R

--- a/infrastructure-formula/infrastructure/salt/master.sls
+++ b/infrastructure-formula/infrastructure/salt/master.sls
@@ -1,5 +1,5 @@
 {%- set extrascriptdir = '/usr/local/sbin/' -%}
-{%- set extrascripts = ['state-apply-super-async.sh'] -%}
+{%- set extrascripts = ['qjid', 'state-apply-super-async.sh'] -%}
 {%- set extrapackages = ['salt-keydiff'] + salt['pillar.get']('infrastructure:salt:formulas', []) -%}
 
 include:


### PR DESCRIPTION
For querying jobs with lots of output it is often useful to utilize a pager, but one does not want to miss out on color when doing so. Combining these desires makes for a rather long command to type, and reusing it requires the need to replace the ID inconveniently located in the middle.
Make this easier by adding a small helper script.