### PR TITLE
os_update: AccuracySec/RandomizedDelaySec

### DIFF
--- a/os_update-formula/pillar.example
+++ b/os_update-formula/pillar.example
@@ -8,6 +8,10 @@ os-update:
   # time: 'Thu *-*-01/4 02:00:00'
   time: false
 
+  # additional, optional, overrides for the timer unit
+  accuracysec: 1us
+  randomizeddelaysec: 20
+
   # options written to /etc/os-update.conf
   update_cmd: auto
   reboot_cmd: auto


### PR DESCRIPTION
Allow override of these timer settings if more precision for execution than assumed by the default settings shipped with the package is needed.

To avoid additional logic around the "watch" statement, replace it with
a reverse requisite.