### PR TITLE
libvirt: add libvirt-daemon

### DIFF
--- a/libvirt-formula/libvirt/init.sls
+++ b/libvirt-formula/libvirt/init.sls
@@ -29,6 +29,7 @@ libvirt_packages:
     - pkgs:
       - patterns-server-kvm_server
       - libvirt-client
+      - libvirt-daemon
       {%- for config in libvirt_configs %}
       - libvirt-daemon-config-{{ config }}
       {%- endfor %}


### PR DESCRIPTION
This was not needed in the past, but it seems the Requires of the other packages changed to no longer pull it in. It provides the libvirtd services.