### PR TITLE
infrastructure.libvirt: manage directories

### DIFF
--- a/infrastructure-formula/infrastructure/libvirt/directories.sls
+++ b/infrastructure-formula/infrastructure/libvirt/directories.sls
@@ -1,0 +1,6 @@
+hypervisor_directories:
+  file.directory:
+    - names:
+      {%- for subdir in ['', 'agents', 'disks', 'domains', 'networks', 'os-images', 'nvram'] %}
+      - {{ salt['pillar.get']('infrastructure:kvm_topdir') }}/{{ subdir }}
+      {%- endfor %}


### PR DESCRIPTION
Move this state from the openSUSE downstream Salt to the infrastructure formula, as it is relevant for all our infrastructures.