### PR TITLE
network: exclude ethtool_options from lowercasing

### DIFF
--- a/network-formula/network/wicked/interfaces.sls
+++ b/network-formula/network/wicked/interfaces.sls
@@ -42,6 +42,7 @@ include:
 {%- endif %}
 
 {%- for option, value in config.items() %}
+{%- set option = option | lower %}
 {%- if value is sameas true %}
 {%- set value = 'yes' %}
 {%- elif value is sameas false %}
@@ -50,10 +51,9 @@ include:
 {%- else %}
 {%- set value = 'no' %}
 {%- endif %}
-{%- else %}
+{%- elif option != 'ethtool_options' %}
 {%- set value = value | lower %}
 {%- endif %}
-{%- set option = option | lower %}
 {%- if not option in ['address', 'addresses'] %}
 {%- do ifcfg_data[interface].update({option: value}) %}
 {%- endif %}

--- a/network-formula/pillar.example
+++ b/network-formula/pillar.example
@@ -35,6 +35,8 @@ network:
       addresses:
         - 192.168.101.1/24
         - fe80::1/64
+    mlx0:
+      ethtool_options: -K foo rxvlan off
   # each listed route will be written into /etc/sysconfig/network/routes and applied
   # "default4" and "default6" will be written as "default"
   routes:


### PR DESCRIPTION
The ETHTOOL_OPTIONS setting takes case sensitive command line arguments as a value.

This also solves a previously undetected issue with configuring
STARTMODE if it was passed uppercased in the pillar.