### PR TITLE
multipath: stop socket activation on 15.6

### DIFF
--- a/multipath-formula/multipath/init.sls
+++ b/multipath-formula/multipath/init.sls
@@ -40,6 +40,21 @@ multipath_service_reload:
     - require:
       - pkg: multipath_packages
 
+{%- if grains['osrelease'] | float > 15.5 %}
+multipath_service:
+  service.running:
+    - name: multipathd
+    - enable: true
+    - require:
+      - pkg: multipath_packages
+      - file: multipath_config
+
+multipath_socket:
+  service.dead:
+    - name: multipathd.socket
+
+{%- else %}
+
 multipath_socket:
   service.running:
     - name: multipathd.socket
@@ -47,3 +62,4 @@ multipath_socket:
     - require:
       - pkg: multipath_packages
       - file: multipath_config
+{%- endif %}


### PR DESCRIPTION
From multipath-tools.changes:

```
- Update to version 0.9.7+140+suse.2d78457:
  * Socket activation via multipathd.socket has been disabled by default
  * because it has undesirable side effects on systems without multipath.
  * Users with multipath hardware should enable multipathd.service
```

This is now shipped with 15.6, making it no longer possible to enable multipathd.socket there without overriding the unit defaults. Follow the recommendation and enable the service unit instead.