### PR TITLE
Python pillar library

### DIFF
--- a/infrastructure-formula/python/.gitignore
+++ b/infrastructure-formula/python/.gitignore
@@ -1,0 +1,4 @@
+*.egg-info
+__pycache__
+dist
+venv

--- a/infrastructure-formula/python/README.md
+++ b/infrastructure-formula/python/README.md
@@ -1,0 +1,24 @@
+# Python pillar helpers
+
+A Python library to be used in `#!py` pillar SLS files. It allows for rendering of formula pillars based off data in YAML datasets.
+The logic is opinionated and specific to the architecture of our code based infrastructure.
+
+## Usage
+
+Example pillar file `network.sls`:
+
+```
+#!py
+from opensuse_infrastructure_formula.pillar import network
+
+def run():
+    return network.generate_network_pillar(
+            [
+                'iac_experts.example.com',
+            ],
+            __grains__['domain'],
+            __grains__['host'],
+    )
+```
+
+All modules are aimed to be named by the top level pillar they generate and contain a generation function which directly returns the relevant Python data structure.

--- a/infrastructure-formula/python/main/__init__.py
+++ b/infrastructure-formula/python/main/__init__.py
@@ -1,0 +1,18 @@
+"""
+Copyright (C) 2024 Georg Pfuetzenreuter <mail+opensuse@georg-pfuetzenreuter.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from .__version__ import __version__ as __version__

--- a/infrastructure-formula/python/main/__version__.py
+++ b/infrastructure-formula/python/main/__version__.py
@@ -1,0 +1,18 @@
+"""
+Copyright (C) 2024 Georg Pfuetzenreuter <mail+opensuse@georg-pfuetzenreuter.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+__version__ = '1.0'

--- a/infrastructure-formula/python/pillar/__init__.py
+++ b/infrastructure-formula/python/pillar/__init__.py
@@ -1,0 +1,19 @@
+"""
+Copyright (C) 2024 Georg Pfuetzenreuter <mail+opensuse@georg-pfuetzenreuter.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from opensuse_infrastructure_formula.__version__ import \
+    __version__ as __version__

--- a/infrastructure-formula/python/pillar/infrastructure.py
+++ b/infrastructure-formula/python/pillar/infrastructure.py
@@ -1,0 +1,154 @@
+"""
+Copyright (C) 2024 Georg Pfuetzenreuter <mail+opensuse@georg-pfuetzenreuter.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from logging import getLogger
+
+from yaml import safe_load
+
+root = '/srv/salt-git/pillar'
+
+log = getLogger(__name__).debug
+
+def generate_infrastructure_pillar(enabled_domains):
+    pillar = {
+        'infrastructure': {
+            'domains': {},
+        }
+    }
+
+    for domain in enabled_domains:
+        pillar['infrastructure']['domains'][domain] = {
+            'clusters': {},
+            'machines': {},
+        }
+
+        domainpillar = pillar['infrastructure']['domains'][domain]
+        domaindir = f'{root}/domain/'
+        mydomaindir = f'{domaindir}{domain.replace(".", "_")}'
+
+        msg = f'Parsing domain {domain}'
+        log(f'{msg} ...')
+
+        domaindata = {
+                'clusters': {},
+                'hosts': {},
+                'inherited_clusters': {},
+        }
+
+        for file in ['clusters', 'hosts']:
+            with open(f'{mydomaindir}/{file}.yaml') as fh:
+                domaindata[file] = safe_load(fh)
+
+        for cluster, clusterconfig in domaindata['clusters'].items():
+            log(f'{msg} => cluster {cluster} ...')
+
+            if 'delegate_to' in clusterconfig:
+                delegated_domain = clusterconfig['delegate_to']
+
+                with open(f'{domaindir}/{delegated_domain}/clusters.yaml') as fh:
+                    domaindata['inherited_clusters'].update({
+                        delegated_domain: safe_load(fh),
+                    })
+
+                if cluster in domaindata['inherited_clusters']:
+                    clusterconfig = domaindata['inherited_clusters'][cluster]
+                else:
+                    log(f'Delegation of cluster {cluster} to {delegated_domain} is not possible!')
+
+            clusterpillar = {
+                    'storage': clusterconfig['storage'],
+            }
+
+            if 'primary_node' in clusterconfig:
+                clusterpillar['primary'] = clusterconfig['primary_node']
+
+            if 'netapp' in clusterconfig:
+                clusterpillar.update({
+                    'netapp': clusterconfig['netapp'],
+                })
+
+            log(clusterpillar)
+            domainpillar['clusters'][cluster] = clusterpillar
+
+        for host, hostconfig in domaindata['hosts'].items():
+            log(f'{msg} => host {host} ...')
+
+            hostpillar = {
+                    'cluster': hostconfig['cluster'],
+                    'disks': hostconfig.get('disks', {}),
+                    'extra': {
+                        'legacy': hostconfig.get('legacy_boot', False),
+                    },
+                    'image': hostconfig.get('image', 'admin-minimal-latest'),
+                    'interfaces': {},
+                    'ram': hostconfig['ram'],
+                    'vcpu': hostconfig['vcpu'],
+            }
+
+            if 'node' in hostconfig:
+                node = hostconfig['node']
+
+                # the node key is compared against the hypervisor minion ID, which is always a FQDN in our infrastructure
+                if '.' in node:
+                    hostpillar['node'] = node
+                else:
+                    hostpillar['node'] = f'{node}.{domain}'
+
+            hostinterfaces = hostconfig.get('interfaces', {})
+
+            ip4 = hostconfig.get('ip4')
+            ip6 = hostconfig.get('ip6')
+
+            if not ip4 and not ip6 and hostinterfaces:
+                if 'primary_interface' in hostconfig:
+                    interface = hostconfig['primary_interface']
+                elif len(hostinterfaces) == 1:
+                    interface = next(iter(hostinterfaces))
+                else:
+                    interface = 'eth0'
+
+                if interface in hostinterfaces:
+                    ip4 = hostinterfaces[interface].get('ip4')
+                    ip6 = hostinterfaces[interface].get('ip6')
+
+            hostpillar['ip4'] = ip4
+            hostpillar['ip6'] = ip6
+
+            for interface, ifconfig in hostinterfaces.items():
+                iftype = ifconfig.get('type', 'direct')
+
+                ifpillar = {
+                        'mac': ifconfig['mac'],
+                        'type': iftype,
+                        'source': ifconfig['source'] if 'source' in ifconfig else f'x-{interface}',
+                }
+
+                if iftype == 'direct':
+                    ifpillar['mode'] = ifconfig.get('mode', 'bridge')
+
+                for i in [4, 6]:
+                    ipf = f'ip{i}'
+
+                    if ipf in ifconfig:
+                        ifpillar[ipf] = ifconfig[ipf]
+
+                hostpillar['interfaces'][interface] = ifpillar
+
+            log(hostpillar)
+            domainpillar['machines'][host] = hostpillar
+
+    return pillar

--- a/infrastructure-formula/python/pillar/juniper_junos.py
+++ b/infrastructure-formula/python/pillar/juniper_junos.py
@@ -1,0 +1,179 @@
+"""
+Copyright (C) 2024 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from bisect import insort
+from ipaddress import ip_network
+from logging import getLogger
+from pathlib import PosixPath
+
+import yaml
+
+root = '/srv/salt-git/pillar'
+
+log = getLogger(__name__)
+
+def generate_juniper_junos_pillar(enabled_domains, minion_id, spacemap):
+    minion = minion_id.replace('LAB-', '')
+    data = {'networks': {}, 'switching': {}}
+    config = {}
+    log.debug('Starting juniper_junos pillar construction ...')
+
+    minion_s = minion.split('-')
+    if len(minion_s) != 4:
+        log.error('Cannot parse minion ID')
+        return {}
+    space = minion_s[1].lower()
+    log.debug(f'Minion space set to "{space}"')
+
+    for domain in enabled_domains:
+        domain_space = domain.split('.')[0]
+        if domain_space in spacemap:
+            domain_space = spacemap[domain_space]
+        log.debug(f'Domain space set to "{domain_space}"')
+        domain = domain.replace('.', '_')
+
+        for dataset in data.keys():
+            log.debug(f'Scanning domain {domain}, dataset {dataset} ...')
+            file = f'{root}/domain/{domain}/{dataset}.yaml'
+
+            if PosixPath(file).is_file():
+                with open(file) as fh:
+
+                    if dataset == 'switching':
+                        log.debug('Updating data ...')
+                        data[dataset].update(yaml.safe_load(fh))
+
+                    elif dataset == 'networks':
+                        log.debug('Not updating data, scanning networks ...')
+                        for network, nwconfig in yaml.safe_load(fh).items():
+                            done = False
+
+                            for existing_network, existing_nwconfig in data[dataset].items():
+                                if network == existing_network or nwconfig.get('id') == existing_nwconfig.get('id'):
+                                    mynetwork = existing_network
+                                    log.debug(f'Mapping network {network} to existing network {mynetwork}')
+
+                                    if nwconfig.get('description') != data[dataset][mynetwork].get('description'):
+                                        log.warning(f'Conflicting descriptions in network {mynetwork}')
+                                    if nwconfig.get('id') != data[dataset][mynetwork].get('id'):
+                                        log.error(f'Conflicting ID: {network} != {mynetwork}, refusing to continue!')
+                                        return {}
+
+                                    if 'groups' not in data[dataset][mynetwork]:
+                                        data[dataset][mynetwork]['groups'] = []
+                                    for group in nwconfig.get('groups', []):
+                                        insort(data[dataset][mynetwork]['groups'], group)
+
+                                    done = True
+                                    break
+
+                            if not done:
+                                if space == domain_space:
+                                    log.debug(f'Creating new network {network}')
+                                    data[dataset][network] = nwconfig
+                                else:
+                                    log.debug(f'Ignoring network {network}')
+
+            else:
+                log.warning(f'File {file} does not exist.')
+
+    if minion in data['switching']:
+        config.update(data['switching'][minion])
+    else:
+        return {}
+
+    log.debug(f'Constructing juniper_junos pillar for {minion}')
+
+    vlids = []
+    groups = {}
+    for interface, ifconfig in config.get('interfaces', {}).items():
+        log.debug(f'Parsing interface {interface} ...')
+        for vlid in ifconfig.get('vlan', {}).get('ids', []):
+            if vlid not in vlids:
+                vlids.append(vlid)
+
+        group = None
+        if 'group' in ifconfig:
+            group = ifconfig['group']
+        elif 'addresses' in ifconfig:
+            group = '__lonely'
+        elif 'vlan' in ifconfig and 'all' in ifconfig['vlan'].get('ids', []):
+            group = '__all'
+        if group:
+            if group not in groups:
+                groups.update({group: {'interfaces': [], 'networks': []}})  # noqa 206
+            log.debug(f'Appending interface {interface} to group {group}')
+            groups[group]['interfaces'].append(interface)
+
+    group_names = groups.keys()
+
+    for network, nwconfig in data['networks'].items():
+        matching_groups = [group for group in nwconfig.get('groups', []) if group in group_names]
+
+        if nwconfig['id'] in vlids or any(matching_groups) or network.startswith(('ICCL_', 'ICCP_')):
+            log.debug(f'Adding network {network} to config ...')
+            if 'vlans' not in config:
+                config.update({'vlans': {}})
+            if network not in config['vlans']:
+                config['vlans'].update({network: {}})
+            config['vlans'][network].update({'id': nwconfig['id']})
+            if 'description' in nwconfig:
+                config['vlans'][network].update({'description': nwconfig['description']})
+            for group in matching_groups:
+                groups[group]['networks'].append(network)
+
+    for group, members in groups.items():
+        for interface in members['interfaces']:
+            ifconfig = config['interfaces'][interface]
+
+            unit = 0
+            if '.' in interface:
+                ifsplit = interface.split('.')
+                ifname = ifsplit[0]
+                ifsuffix = ifsplit[1]
+                if ifsuffix.isdigit():
+                    unit = int(ifsuffix)
+
+            if 'units' not in ifconfig:
+                ifconfig.update({'units': {}})
+            if unit not in ifconfig['units']:
+                ifconfig['units'].update({unit: {}})
+            if members['networks']:
+                ifconfig['units'][unit].update({'vlan': {'ids': [], 'type': ifconfig.get('vlan', {}).get('type', 'access')}})  # noqa 206
+            for network in members['networks']:
+                if config['vlans'][network]['id'] not in ifconfig['units'][unit]['vlan']['ids']:
+                    insort(ifconfig['units'][unit]['vlan']['ids'], config['vlans'][network]['id'])
+            if 'addresses' in ifconfig:
+                for address in ifconfig['addresses']:
+                    address_version = ip_network(address, False).version
+                    if address_version == 4:
+                        family = 'inet'
+                    elif address_version == 6:
+                        family = 'inet6'
+                    else:
+                        log.error(f'Illegal address: {address}')
+                    if family not in ifconfig['units'][unit]:
+                        ifconfig['units'][unit].update({family: {'addresses': []}})  # noqa 206
+                    ifconfig['units'][unit][family]['addresses'].append(address)
+                del ifconfig['addresses']
+            elif group == '__all':
+                ifconfig['units'][unit].update({'vlan': {'ids': ['all'], 'type': ifconfig.get('vlan', {}).get('type', 'trunk')}})  # noqa 206
+            if unit > 0:
+                config['interfaces'][ifname] = config['interfaces'].pop(interface)
+
+    log.debug(f'Returning juniper_junos pillar for {minion}: {config}')
+    return {'juniper_junos': config}

--- a/infrastructure-formula/python/pillar/network.py
+++ b/infrastructure-formula/python/pillar/network.py
@@ -1,0 +1,159 @@
+"""
+Copyright (C) 2024 Georg Pfuetzenreuter <mail+opensuse@georg-pfuetzenreuter.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from logging import getLogger
+
+from yaml import safe_load
+
+root = '/srv/salt-git/pillar'
+
+log = getLogger(__name__).debug
+
+def generate_network_pillar(enabled_domains, domain, host):
+    if domain not in enabled_domains:
+        return {}
+
+    domaindir = f'{root}/domain/{domain.replace(".", "_")}'
+
+    msg = f'common.network, host {host}:'
+
+    domaindata = {
+            'hosts': {},
+            'networks': {},
+    }
+
+    for file in domaindata.keys():
+        with open(f'{domaindir}/{file}.yaml') as fh:
+            domaindata[file] = safe_load(fh)
+
+    # machine not in hosts, can be an error or expected (for example because the machine is bare metal or in an unsupported location)
+    if host not in domaindata['hosts']:
+        return {}
+
+    pillar = {}
+
+    hostconfig = domaindata['hosts'][host]
+    ifconfig   = hostconfig.get('interfaces', {})
+
+    if 'primary_interface' in hostconfig:
+        primary_interface = hostconfig['primary_interface']
+
+    elif len(ifconfig) == 1:
+        primary_interface = next(iter(ifconfig))
+
+    else:
+        interface_candidates = [interface for interface in ifconfig.keys() if not interface.endswith('-ur')]
+
+        if len(interface_candidates) == 1:
+            primary_interface = next(iter(interface_candidates))
+
+        else:
+            primary_interface = 'eth0'
+
+    log(f'{msg} primary interface set to {primary_interface}')
+
+    if primary_interface in ifconfig and ( 'ip4' in ifconfig[primary_interface] or 'ip6' in ifconfig[primary_interface] ):
+        ip4 = ifconfig[primary_interface].get('ip4')
+        ip6 = ifconfig[primary_interface].get('ip6')
+
+        # if an interface name contains a hyphen, it can be assumed to match our short VLAN nameing convention
+        if '-' in primary_interface:
+            shortnet = primary_interface
+
+        # alternatively assess the network segment based off the source (hypervisor) interface
+        else:
+            shortnet = ifconfig[primary_interface].get('source', '').replace('x-', '')
+
+        log(f'{msg} shortnet set to {shortnet}')
+
+    # if no primary interface is available, find and apply addresses defined outside of an "interfaces" block (single interface hosts might use this)
+    else:
+        log(f'{msg} trying to use generic interface addresses')
+        ip4 = hostconfig.get('ip4')
+        ip6 = hostconfig.get('ip6')
+        ifconfig = {}
+        shortnet = None
+
+    ifconfig.pop(primary_interface, None)
+
+    log(f'{msg} primary IPv4 address set to {ip4}')
+    log(f'{msg} primary IPv6 address set to {ip6}')
+
+    if ip4 is not None or ip6 is not None or ifconfig:
+        pillar['network'] = {}
+
+        pillar['network']['interfaces'] = {}
+
+        if ip4 is not None or ip6 is not None:
+            pillar['network']['interfaces'][primary_interface] = {
+                    'addresses': [],
+            }
+            addresses = pillar['network']['interfaces'][primary_interface]['addresses']
+
+            if ip4 is not None:
+                addresses.append(ip4)
+
+            if ip6 is not None:
+                addresses.append(ip6)
+
+            # firewall is managed through the firewalld pillar, avoid conflict with the wicked firewalld integration
+            pillar['network']['interfaces'][primary_interface]['firewall'] = False
+
+        for add_interface, add_ifconfig in ifconfig.items():
+            if 'ip4' in add_ifconfig or 'ip6' in add_ifconfig:
+                log(f'{msg} configuring additional interface {add_interface}')
+                pillar['network']['interfaces'][add_interface] = {
+                        'addresses': [],
+                }
+                add_addresses = pillar['network']['interfaces'][add_interface]['addresses']
+
+                if 'ip4' in add_ifconfig:
+                    add_addresses.append(add_ifconfig['ip4'])
+
+                if 'ip6' in add_ifconfig:
+                    add_addresses.append(add_ifconfig['ip6'])
+
+                # explanation above
+                pillar['network']['interfaces'][add_interface]['firewall'] = False
+
+    if shortnet:
+        for network, nwconfig in domaindata['networks'].items():
+            if network == shortnet or nwconfig.get('short') == shortnet:
+                longnet = network
+                break
+        else:
+            longnet = None
+
+        log(f'{msg} network set to {longnet}')
+
+        if longnet:
+            nwconfig = domaindata['networks'][network]
+
+            if 'gw4' in nwconfig or 'gw6' in nwconfig:
+                pillar['network']['routes'] = {}
+
+                if ip4 is not None and 'gw4' in nwconfig:
+                    pillar['network']['routes']['default4'] = {
+                            'gateway': nwconfig['gw4'],
+                    }
+
+                if ip6 is not None and 'gw6' in nwconfig:
+                    pillar['network']['routes']['default6'] = {
+                            'gateway': nwconfig['gw6'],
+                    }
+
+    return pillar

--- a/infrastructure-formula/python/pyproject.toml
+++ b/infrastructure-formula/python/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ['setuptools', 'wheel']
+build-backend = 'setuptools.build_meta'
+
+[project]
+name = 'opensuse_infrastructure_formula'
+authors = [
+  { name='Georg Pfuetzenreuter', email='georg+opensuse@lysergic.dev' },
+]
+dynamic = ['version']
+requires-python = '>=3.6'
+
+dependencies = [
+  'salt',
+]
+
+[tool.setuptools.dynamic]
+version = {attr = 'opensuse_infrastructure_formula.__version__'}
+readme = {file = ['README.md']}
+
+[tool.setuptools]
+packages = [
+  'opensuse_infrastructure_formula',
+  'opensuse_infrastructure_formula.pillar',
+]
+
+[tool.setuptools.package-dir]
+opensuse_infrastructure_formula = 'main'
+'opensuse_infrastructure_formula.pillar' = 'pillar'

--- a/infrastructure-formula/python/setup.cfg
+++ b/infrastructure-formula/python/setup.cfg
@@ -1,0 +1,14 @@
+[metadata]
+name = opensuse_infrastructure_formula
+version = attr: opensuse_infrastructure_formula.__version__
+author = Georg Pfuetzenreuter
+author_email = georg+python@lysergic.dev
+
+[options]
+python_requires = >=3.6
+packages =
+  opensuse_infrastructure_formula
+  opensuse_infrastructure_formula.pillar
+package_dir =
+  opensuse_infrastructure_formula = main
+  opensuse_infrastructure_formula.pillar = pillar

--- a/packaging/templates/infrastructure-formulas.spec.j2
+++ b/packaging/templates/infrastructure-formulas.spec.j2
@@ -19,6 +19,7 @@
 %define fdir %{_datadir}/salt-formulas
 %define sdir %{fdir}/states
 %define mdir %{fdir}/metadata
+%define pythons python3
 Name:           infrastructure-formulas
 Version:        0
 Release:        0
@@ -57,10 +58,25 @@ License:        {{ config.license }}
 {{ config.description if config.description else config.summary ~ '.' }}
 {%- endfor %}
 
+%package -n infrastructure-formula-python
+Summary:        Infrastructure pillar helpers
+BuildRequires:  %{python_module pip}
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module wheel}
+BuildRequires:  %{pythons}
+BuildRequires:  python-rpm-macros
+BuildArch:      noarch
+
+%description -n infrastructure-formula-python
+Python libraries to help with rendering Salt formula pillars using YAML datasets found in the openSUSE infrastructure.
+
 %prep
 mv %{_sourcedir}/salt-formulas-%{version}/* .
 
 %build
+pushd infrastructure-formula/python
+%pyproject_wheel
+popd
 
 %install
 install -dm0755 %{buildroot}%{mdir} %{buildroot}%{sdir} %{buildroot}%{sdir}/_modules %{buildroot}%{sdir}/_states %{buildroot}%{_bindir}
@@ -137,6 +153,10 @@ do
 
 done
 
+pushd infrastructure-formula/python
+%pyproject_install
+popd
+
 %files
 
 %files common
@@ -149,5 +169,14 @@ done
 {% for formula in formulas.keys() %}
 %files -n {{ formula }}-formula -f {{ formula }}.files
 {% endfor %}
-%changelog
 
+%files -n infrastructure-formula-python
+%dir %{python_sitelib}/opensuse_infrastructure_formula
+%pycache_only %{python_sitelib}/opensuse_infrastructure_formula/__pycache__
+%{python_sitelib}/opensuse_infrastructure_formula/__{init,version}__.py
+%dir %{python_sitelib}/opensuse_infrastructure_formula/pillar
+%pycache_only %{python_sitelib}/opensuse_infrastructure_formula/pillar/__pycache__
+%{python_sitelib}/opensuse_infrastructure_formula/pillar/*.py
+%{python_sitelib}/opensuse_infrastructure_formula-*.dist-info
+
+%changelog


### PR DESCRIPTION
This imports the Python based pillar logic used in our Salt infrastructures in the form of reusable libraries, helping us to deduplicate code and making it easier to maintain changes. The respective "#!py" pillars will then be adjusted to reference library calls, with only the infrastructure specific data needing to be passed as function parameters.