### PR TITLE
infra.suse_ha: auto-converge for VM migrations

### DIFF
--- a/infrastructure-formula/infrastructure/suse_ha/resources.sls
+++ b/infrastructure-formula/infrastructure/suse_ha/resources.sls
@@ -56,6 +56,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- set instance_attributes = {
       'config': domaindir ~ '/' ~ machine ~ '.xml',
       'hypervisor': 'qemu:///system',
+      'migrate_options': '--auto-converge',
       'autoset_utilization_cpu': 'true',
       'autoset_utilization_hv_memory': 'true',
       'migration_transport': 'tcp',


### PR DESCRIPTION
Enable autoconvergence by default to prevent live migrations of busy VMs from staying blocked.

https://wiki.qemu.org/Features/AutoconvergeLiveMigration