### PR TITLE
infra.suse_ha: block on failed migrations

### DIFF
--- a/infrastructure-formula/infrastructure/suse_ha/resources.sls
+++ b/infrastructure-formula/infrastructure/suse_ha/resources.sls
@@ -67,8 +67,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       'monitor': {'timeout': 30, 'interval': 10},
       'start': {'timeout': 90, 'interval': 0},
       'stop': {'timeout': 90, 'interval': 0},
-      'migrate_to': {'timeout': 600, 'interval': 0},
-      'migrate_from': {'timeout': 550, 'interval': 0}
+      'migrate_to': {
+        'timeout': 600,
+        'interval': 0,
+        'on-fail': 'block',
+      },
+      'migrate_from': {
+        'timeout': 550,
+        'interval': 0,
+        'on-fail': 'block',
+      }
 } %}
 
 {%- set meta_attributes = {

--- a/suse_ha-formula/suse_ha/files/cib/primitive.xml.j2
+++ b/suse_ha-formula/suse_ha/files/cib/primitive.xml.j2
@@ -11,7 +11,8 @@
         {%- if config['operations'] | length > 0 %}
         <operations>
           {%- for op, opconfig in config['operations'].items() %}
-          <op name="{{ op }}" timeout="{{ opconfig ['timeout'] }}" interval="{{ opconfig ['interval'] }}" id="{{ resource_id }}-{{ op }}-{{ opconfig ['interval'] }}"/>
+          {%- set interval = opconfig.pop('interval') %}
+          <op name="{{ op }}" timeout="{{ opconfig.pop('timeout') }}" interval="{{ interval }}"{% for property, value in opconfig.items() %}{{ ' ' ~ property ~ '="' ~ value ~ '"' }}{% endfor %} id="{{ resource_id }}-{{ op }}-{{ interval }}"/>
           {%- endfor %}
         </operations>
         {%- endif %}


### PR DESCRIPTION
- suse_ha: allow arbitrary operation properties

Keep the existing, mandatory, operation properties but additionally render custom ones if any are specified in the pillar for a given resource.
The slightly "awkward" handling by popping the mandatory ones first is
to avoid the application reporting ordering errors if invalid properties are
passed.

- infra.suse_ha: block on failed migrations

By default a migration failure, for example due to an unreachable Libvirt TCP socket on the target hypervisor, would cause the virtual machine resource to get stopped on the source, and then started again on the target hypervisor. In our infrastructure this behavior is not desirable - rather abort the operation and leave the VM running on the source hypervisor, allowing an administrator to resolve the migration issue without having to worry about interrupted services due to unplanned VM restarts.