### PR TITLE
Add dist, venv, egg-info to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .vagrant/
 __pycache__/
 .scullery_*
+*.egg-info
+dist/
+venv/


### PR DESCRIPTION
For development of Python code using pip/setuptools in the tree.