### PR TITLE
infrastructure.salt: drop pillar_network

### DIFF
--- a/infrastructure-formula/infrastructure/salt/proxy_master.sls
+++ b/infrastructure-formula/infrastructure/salt/proxy_master.sls
@@ -1,5 +1,4 @@
 {%- set domain = grains['domain'] %}
-{%- set highpillar = salt['pillar.get']('infrastructure:salt', {}) -%}
 {%- set proxydomain = salt['pillar.get']('infrastructure:salt:proxy_domains:' ~ domain) -%}
 {%- set pkidir = '/etc/salt/pki/master/minions/' %}
 
@@ -16,19 +15,3 @@ salt_proxy_preseed:
             {{ proxydomain['certificate'] | base64_decode | indent(12) }}
       {%- endfor %}
 {%- endif %}
-
-/srv/pillar_network/network_data/switches:
-  file.directory:
-    - user: {{ highpillar.get('sync_user', 'sync') }}
-    - group: salt
-    - makedirs: true
-
-/srv/pillar_network/top.sls:
-  file.managed:
-    - group: salt
-    - contents: |
-        {% raw %}{{ saltenv }}{%- endraw %}:
-          '*':
-            - network_data
-    - require:
-      - file: /srv/pillar_network/network_data/switches


### PR DESCRIPTION
This directory structure is no longer used, pillar for network devices is provided equally to any other minion.