### PR TITLE
infrastructure.salt: site grain for proxy minions

### DIFF
--- a/infrastructure-formula/infrastructure/salt/proxy_networkautomation.sls
+++ b/infrastructure-formula/infrastructure/salt/proxy_networkautomation.sls
@@ -85,6 +85,9 @@ salt_pod_proxy_config:
               {%- if 'domain' in mypillar %}
               domain: {{ mypillar['domain'] }}
               {%- endif %}
+              {%- if 'site' in mypillar %}
+              site: {{ mypillar['site'] }}
+              {%- endif %}
       - /etc/salt-pod/proxy_schedule.conf:
         - source: salt://{{ slspath }}/files/etc/salt/schedule.conf.j2
         - template: jinja


### PR DESCRIPTION
Needed for use in the openSUSE infrastructure, where the site grain is used to differentiate locations.