### PR TITLE
infrastructure.salt: split out Podman states

### DIFF
--- a/infrastructure-formula/infrastructure/salt/podman.sls
+++ b/infrastructure-formula/infrastructure/salt/podman.sls
@@ -1,0 +1,27 @@
+salt_pod_user:
+  group.present:
+    - name: autopod
+    - system: True
+    - gid: 900
+
+  user.present:
+    - name: autopod
+    - system: True
+    - home: /var/lib/autopod
+    - uid: 900
+    - gid: 900
+    - require:
+      - group: autopod
+    - require_in:
+      - User session for autopod is initialized at boot
+
+  cmd.run:
+    - name: 'usermod --add-subuids 100000-165535 --add-subgids 100000-165535 autopod'
+    - onchanges:
+      - group: autopod
+      - user: autopod
+    - require_in:
+      - User session for autopod is initialized at boot
+
+include:
+  - podman.containers

--- a/infrastructure-formula/infrastructure/salt/proxy_networkautomation.sls
+++ b/infrastructure-formula/infrastructure/salt/proxy_networkautomation.sls
@@ -2,30 +2,8 @@
 {%- set mypillar = highpillar.get('proxy', {}) -%}
 
 {%- if mypillar %}
-salt_pod_user:
-  group.present:
-    - name: autopod
-    - system: True
-    - gid: 900
-
-  user.present:
-    - name: autopod
-    - system: True
-    - home: /var/lib/autopod
-    - uid: 900
-    - gid: 900
-    - require:
-      - group: autopod
-    - require_in:
-      - User session for autopod is initialized at boot
-
-  cmd.run:
-    - name: 'usermod --add-subuids 100000-165535 --add-subgids 100000-165535 autopod'
-    - onchanges:
-      - group: autopod
-      - user: autopod
-    - require_in:
-      - User session for autopod is initialized at boot
+include:
+  - .podman
 
 salt_pod_dirs:
   file.directory:
@@ -128,9 +106,6 @@ salt_proxy_config_{{ minion }}:
 
 {%- endfor %}
 {%- endif %}
-
-include:
-  - podman.containers
 
 salt_proxy_scripts:
   file.managed:


### PR DESCRIPTION
Allow for use of these for purposes other than network automation.