### PR TITLE
rsync: join with space

### DIFF
--- a/rsync-formula/rsync/macros.jinja
+++ b/rsync-formula/rsync/macros.jinja
@@ -1,6 +1,6 @@
 {#-
 Jinja macros file for the rsync Salt states
-Copyright (C) 2023-2024 Georg Pfuetzenreuter <mail+opensuse@georg-pfuetzenreuter.net>
+Copyright (C) 2023-2025 Georg Pfuetzenreuter <mail+opensuse@georg-pfuetzenreuter.net>
 Copyright (C) 2023 SUSE LLC
 
 This program is free software: you can redistribute it and/or modify
@@ -20,7 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {%- macro contents(data, delimiter=' = ') -%}
   {%- for setting, value in data.items() %}
     {%- if value is not string and value is sequence %}
-      {%- set value = ', '.join(value) -%}
+      {%- set value = ' '.join(value) -%}
     {%- endif %}
             {{ setting ~ delimiter ~ value }}
   {%- endfor %}


### PR DESCRIPTION
Whilst some parameters in the manual take "a list of comma- and/or whitespace-separated patterns", others only take "a space-separated list". As the option to separate by whitespace seems most universal, replace comma with whitespace joining for lists in the pillar.