### PR TITLE
Preserve hyphen in packaged state directories

### DIFF
--- a/packaging/templates/infrastructure-formulas.spec.j2
+++ b/packaging/templates/infrastructure-formulas.spec.j2
@@ -91,17 +91,20 @@ do
   fname="${formula%%-*}"
 
   src_metadata="$formula/metadata"
+  dst_metadata="%{mdir}/$fname"
+
   src_states="$formula/$fname"
+  dst_states="%{sdir}/$fname"
   if [ ! -d "$src_states" ]
   then
-    src_states="$formula/${fname//_/-}"
+    fname_sub="${fname//_/-}"
+    src_states="$formula/$fname_sub"
+    dst_states="%{sdir}/$fname_sub"
   fi
+
   src_execumodules="$formula/_modules"
   src_statemodules="$formula/_states"
   src_bin="$formula/bin"
-
-  dst_metadata="%{mdir}/$fname"
-  dst_states="%{sdir}/$fname"
 
   if [ -d "$src_metadata" ]
   then


### PR DESCRIPTION
Avoid installing a state directory with an underscore if it is present with a hyphen in the repository to allow for references in the templates (for example to a map file) to resolve and to reduce confusion, as one generally expects the state directory name in the repository to match the installed one.
This makes the metadata directory diverge, as that one is still installed by the top formula name, however the metadata matching the formula name is deemed expected.

This is a breaking change, the packaged state "os_update" changes to "os-update" in the next spec rendering.
The packaged "php_fpm" state changing to "php-fpm" is not breaking, as it was broken already and is hereby repaired.