### PR TITLE
389ds: support object specific cleaning

### DIFF
--- a/389ds-formula/pillar.example
+++ b/389ds-formula/pillar.example
@@ -44,9 +44,9 @@
           - '*'  # standard LDAP attribute selectors are supported, but you probably do not want "+", as it would also include attributes managed by the server, such as the change time
           - aci
         # whether to delete objects not managed in the pillar below
-        # note this will so far only cover the deletion of objects under parent objects defined in the pillar
-        # defaults to True
-        clean: true
+        # this is the global default, which defaults to True
+        # the "clean" option in objects below can be used to override this default
+        clean: True
         tree:
           # the top keys under "tree" are the suffixes
           dc=example,dc=com:
@@ -57,7 +57,7 @@
               objectClass:
                 - organizationalUnit
                 - top
-              # only "children" is special - it recurses to further objects
+              # "children" is special - it recurses to further objects
               children:
                 # this becomes "cn=Max Mustermannn,ou=people,dc=example,dc=com"
                 cn=Max Mustermannn:
@@ -90,3 +90,17 @@
                   uidNumber: 99998
                   gidNumber: 99998
                   userPassword: '{PBKDF2-SHA512}100000$zPwioWIiZGQArGMeRtg7a2wC/DlkRWQP$iY2x9Arj7NqZg1d6NnEvw7OPWOokxL9NbAmubY6DfvMI36rx9cJhZcYSXYTS3gcVVTVlQ7RKJJOnMlKKWoYpXA=='
+
+            ou=ext:
+              # override the global "clean" setting
+              clean: False
+              objectClass:
+                - organizationalUnit
+                - top
+              children:
+                ou=subext:
+                  # override the parent "clean" setting
+                  clean: True
+                  objectClass:
+                    - organizationalUnit
+                    - top

--- a/389ds-formula/tests/conftest.py
+++ b/389ds-formula/tests/conftest.py
@@ -19,8 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from shlex import quote
 
 import pytest
-from utils import (DSCONF_FILE, INSTANCE, SUFFIX, cmd, cmd_dsconf,
-                   instance_setup, instance_teardown, salt)
+from utils import INSTANCE, SUFFIX, cmd_dsconf, instance_setup, instance_teardown, salt
 
 
 @pytest.fixture(scope='module')
@@ -115,7 +114,7 @@ def pillar(request):
 
 
 @pytest.fixture
-def salt_state_apply(host, pillar, test):
+def salt_state_apply_main(host, pillar, test):
     print(f'sa pillar: {pillar}')
     print(f'sa test: {test}')
 
@@ -123,7 +122,16 @@ def salt_state_apply(host, pillar, test):
 
     yield salt(host, f'state.apply 389ds pillar={pillar} test={test}')
 
-    # loose cleanup regardless of whether the above changed anything
-    host.run(cmd(['sudo', 'dsctl', INSTANCE, 'remove', '--do-it']))
-    host.run('rpm --quiet -q 389-ds && sudo zypper -nq rm 389-ds')
-    host.run(cmd(['sudo', 'rm', '-f', DSCONF_FILE]))
+    instance_teardown(host)
+
+
+@pytest.fixture
+def salt_state_apply_data(host, pillar, test):
+    print(f'sa pillar: {pillar}')
+    print(f'sa test: {test}')
+
+    pillar = quote(str(pillar))
+
+    yield salt(host, f'state.apply 389ds.data pillar={pillar} test={test}')
+
+    instance_teardown(host)


### PR DESCRIPTION
Allow to manage objects under certain OUs outside of Salt while keeping the general cleanup functionality active by implementing a clean toggle for subordinate objects which, if not defined, inherits the nearest one higher up in the chain. Can also be used in "reverse" if so desired.