### PR TITLE
Initialize Helm formula

### DIFF
--- a/helm-formula/README.md
+++ b/helm-formula/README.md
@@ -1,0 +1,14 @@
+# Salt states for Helm
+
+## Dependencies
+
+This will neither work with the `helm` execution and state modules shipped with Salt core nor with the latest revision of `saltext-helm`.
+It depends on a refactored version of the modules (https://github.com/salt-extensions/saltext-helm/pull/21) and `pyhelm3`.
+
+A compatible extension package can be found in `isv:SUSEInfra:Devel`.
+
+## Available states
+
+`helm`
+
+Ensures packages needed for managing Helm are installed, and ensures releases match the pillar configuration.

--- a/helm-formula/helm/init.sls
+++ b/helm-formula/helm/init.sls
@@ -1,0 +1,21 @@
+{#-
+Salt state file for managing Helm
+Copyright (C) 2026 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-#}
+
+include:
+  - .packages
+  - .releases

--- a/helm-formula/helm/packages.sls
+++ b/helm-formula/helm/packages.sls
@@ -1,0 +1,34 @@
+#!py
+"""
+Salt states for managing Helm packages
+Copyright (C) 2026 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from platform import python_version_tuple
+
+
+def run():
+    python = 'python' + ''.join(python_version_tuple()[:2]) + '-'
+
+    return {'helm-packages': {
+            'pkg.installed': [
+                {'pkgs': [
+                    'helm',
+                    python + 'pyhelm3',
+                    python + 'saltext-helm',
+                ]},
+            ],
+    }}

--- a/helm-formula/helm/releases.sls
+++ b/helm-formula/helm/releases.sls
@@ -1,0 +1,73 @@
+#!py
+"""
+Salt states for managing Helm releases
+Copyright (C) 2026 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from logging import getLogger
+
+log = getLogger(__name__)
+
+def run():
+    states = {}
+    want_releases = __salt__['pillar.get']('helm:releases', {})
+
+    if not want_releases:
+        return states
+
+    have_releases = __salt__['helm.list_releases'](all=True, all_namespaces=True)
+
+    for have in have_releases:
+        have_release = have['name']
+        have_namespace = have['namespace']
+
+        # filter out system charts managed by RKE2 (TODO: allow filtering already in list_releases() to reduce shell calls?)
+        if have_namespace == 'kube-system' and have_release.startswith('rke2-'):
+            continue
+
+        for namespace, releases in want_releases.items():
+            if have_namespace == namespace and have_release in releases:
+                break
+
+        else:
+            log.debug(f'Marking release "{have_release}" in namespace "{have_namespace}" for removal.')
+            states[f'helm-release-absent-{have_namespace}-{have_release}'] = {
+                    'helm.release_absent': [
+                        {'name': have_release},
+                        {'namespace': have_namespace},
+                        {'require': [
+                            {'pkg': 'helm-packages'},
+                        ]},
+                    ],
+            }
+
+    for namespace, releases in want_releases.items():
+        for release, release_config in releases.items():
+            states[f'helm-release-present-{namespace}-{release}'] = {
+                    'helm.release_present': [
+                        {'name': release},
+                        {'namespace': namespace},
+                        {'chart': release_config['chart']},
+                        {'values': release_config.get('values')},
+                        {'description': release_config.get('description')},
+                        {'timeout': release_config.get('timeout', '15s')},
+                        {'require': [
+                            {'pkg': 'helm-packages'},
+                        ]},
+                    ],
+            }
+
+    return states

--- a/helm-formula/metadata/metadata.yml
+++ b/helm-formula/metadata/metadata.yml
@@ -1,0 +1,5 @@
+---
+summary:
+  Salt states for Helm
+description:
+  Salt states for managing Helm.

--- a/helm-formula/pillar.example
+++ b/helm-formula/pillar.example
@@ -1,0 +1,20 @@
+# vim: ft=yaml
+
+helm:
+  releases:
+    # namespace
+    test1:
+      # release name
+      cert-manager:
+        # chart reference is mandatory
+        chart:
+          # chart name can be <registry>/<name> or a OCI URL
+          name: oci://dp.apps.rancher.io/charts/cert-manager
+        # everything below is optional
+          version: 1.19.1
+        values:
+          # all user values can be passed in this mapping
+          crds:
+            enabled: False
+        description: Hello
+        timeout: 5m  # defaults to 15s to avoid unexpected lockup

--- a/helm-formula/tests/conftest.py
+++ b/helm-formula/tests/conftest.py
@@ -1,0 +1,35 @@
+"""
+Helpers for testing of the Helm formula
+Copyright (C) 2026 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def clean(host):
+    yield
+
+    host.run('sudo salt-call --local helm.uninstall_release exporter1 namespace=formula-test')
+
+@pytest.fixture
+def populated(host):
+    host.run('sudo salt-call --local helm.install_or_upgrade_release release_name=exporter1 chart=oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter namespace=formula-test values=\"{"replicas": 2}\"')
+
+    yield
+
+    host.run('sudo salt-call --local helm.uninstall_release exporter1 namespace=formula-test')
+    host.run('sudo salt-call --local helm.uninstall_release exporter2 namespace=formula-test')

--- a/helm-formula/tests/test_state.py
+++ b/helm-formula/tests/test_state.py
@@ -1,0 +1,189 @@
+"""
+Test suite for Salt states in the Helm formula
+Copyright (C) 2026 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from copy import deepcopy
+
+import pytest
+from utils import salt_state_apply
+
+PILLAR = {'helm': {
+            'releases': {
+                'formula-test': {
+                    'exporter1': {
+                        'chart': {
+                            'name': 'oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter',
+                            'version': '11.7.0',
+                        },
+                        'values': {
+                            'replicas': 2,
+                        },
+                    },
+                },
+            },
+        },
+}
+
+STATES = [
+    'pkg_|-helm-packages_|-helm-packages_|-installed',
+    'helm_|-helm-release-present-formula-test-exporter1_|-exporter1_|-release_present',
+]
+
+
+@pytest.mark.parametrize('test', [True, False])
+def test_release_new(host, test, clean):
+    out, err, rc = salt_state_apply(host, PILLAR, test)
+
+    assert rc == 0
+
+    for state in STATES:
+        assert state in out
+
+    assert len(out) == len(STATES)
+
+    low = out[STATES[1]]
+
+    if test:
+        assert low['result'] is None
+        assert low['comment'] == 'Would install release.'
+
+    else:
+        assert low['result'] is True
+        assert low['comment'] == 'Successfully installed release.'
+
+
+@pytest.mark.parametrize('test', [True, False])
+def test_release_nochanges(host, test, populated):
+    out, err, rc = salt_state_apply(host, PILLAR, test)
+
+    assert rc == 0
+
+    for state in STATES:
+        assert state in out
+
+    assert len(out) == len(STATES)
+
+    low = out[STATES[1]]
+
+    assert low['result'] is True
+    assert low['comment'] == 'Release matches the configuration.'
+    assert low['changes'] == {}
+
+
+@pytest.mark.parametrize('test', [True, False])
+def test_release_changes(host, test, populated):
+    changed_pillar = deepcopy(PILLAR)
+    changed_pillar['helm']['releases']['formula-test']['exporter1']['values']['replicas'] = 1
+
+    out, err, rc = salt_state_apply(host, changed_pillar, test)
+
+    assert rc == 0
+
+    for state in STATES:
+        assert state in out
+
+    assert len(out) == len(STATES)
+
+    low = out[STATES[1]]
+
+    if test:
+        assert low['result'] is None
+        assert low['comment'] == 'Would update release.'
+        assert low['changes'] == {
+                'new': {
+                    'values': {
+                        'replicas': 1,
+                    },
+                },
+                'old': {
+                    'values': {
+                        'replicas': 2,
+                    },
+                },
+        }
+
+    else:
+        assert low['result'] is True
+        assert low['comment'] == 'Successfully updated release.'
+        assert low['changes'] == {
+                'new': {
+                    'chart': {
+                        'name': 'prometheus-blackbox-exporter',
+                        'version': '11.7.0',
+                    },
+                    'name': 'exporter1',
+                    'namespace': 'formula-test',
+                    'status': 'deployed',
+                    'values': {
+                        'replicas': 1,
+                    },
+                },
+                'old': {
+                    'values': {
+                        'replicas': 2,
+                    },
+                },
+        }
+
+
+@pytest.mark.parametrize('test', [True, False])
+def test_release_cleanup(host, test, populated):
+    changed_pillar = {'helm': {'releases': {
+        'formula-test': {
+            'exporter2': {
+                'chart': {
+                    'name': 'oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter',
+                    'version': '11.7.0',
+                },
+            },
+        },
+    }}}
+
+    state_absent = 'helm_|-helm-release-absent-formula-test-exporter1_|-exporter1_|-release_absent'
+    state_present = 'helm_|-helm-release-present-formula-test-exporter2_|-exporter2_|-release_present'
+
+    out, err, rc = salt_state_apply(host, changed_pillar, test)
+
+    assert rc == 0
+
+    assert len(out) == 3
+
+    got_states = list(out.keys())
+
+    assert got_states[1] == state_absent
+    assert got_states[2] == state_present
+
+    low = out[state_absent]
+
+    assert low['name'] == 'exporter1'
+
+    if test:
+        assert low['result'] is None
+        assert low['comment'] == 'Would uninstall release.'
+
+    else:
+        assert low['result'] is True
+        assert low['comment'] == 'Successfully uninstalled release.'
+
+    assert low['changes'] == {
+            'old': {
+                'name': 'exporter1',
+            },
+            'new': {
+                'name': None,
+            },
+    }

--- a/helm-formula/tests/utils.py
+++ b/helm-formula/tests/utils.py
@@ -1,0 +1,29 @@
+"""
+Helpers for testing of the Helm formula
+Copyright (C) 2026 SUSE LLC <georg.pfuetzenreuter@suse.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from json import loads
+from shlex import quote
+
+
+def salt_state_apply(host, pillar, test):
+    pillar = quote(str(pillar))
+    result = host.run(f'sudo salt-call --local --out json state.apply helm pillar={pillar} test={test}')
+
+    output = loads(result.stdout)['local']
+
+    return output, result.stderr, result.rc


### PR DESCRIPTION
Basic functionality for managing Helm releases. Might be extended with more features later.

This depends on https://github.com/salt-extensions/saltext-helm/pull/21, but https://build.opensuse.org/package/show/isv:SUSEInfra:Devel/python-saltext-helm is currently built from my fork so it is not a blocker.