### PR TITLE
infrastructure: compare hypervisor node by host

### DIFF
--- a/infrastructure-formula/infrastructure/libvirt/domains.sls
+++ b/infrastructure-formula/infrastructure/libvirt/domains.sls
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -#}
 
 {%- set myid = grains['id'] -%}
+{%- set myhost = grains['host'] -%}
 {%- if pillar['do_vd'] | default(False) and 'delegated_orchestra' in pillar -%}
   {%- do salt.log.debug('libvirt.domains: delegated from orchestration run') -%}
   {%- set dopillar = pillar['delegated_orchestra'] -%}
@@ -59,7 +60,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       {%- if dname == domain or do_all_domains %}
         {%- for machine, config in dpillar['machines'].items() %}
           {%- set machine = machine ~ '.' ~ dname %}
-          {%- if config['cluster'] == cluster and ( not 'node' in config or config['node'] == myid ) %}
+          {%- if config['cluster'] == cluster and ( not 'node' in config or config['node'] == myhost ) %}
             {%- set domainxmlname = machine ~ '.xml' %}
             {%- do domainxmls.append(domainxmlname) %}
             {%- set domainxml = domaindir ~ '/' ~ domainxmlname %}

--- a/infrastructure-formula/python/pillar/infrastructure.py
+++ b/infrastructure-formula/python/pillar/infrastructure.py
@@ -97,11 +97,12 @@ def generate_infrastructure_pillar(enabled_domains):
             if 'node' in hostconfig:
                 node = hostconfig['node']
 
-                # the node key is compared against the hypervisor minion ID, which is always a FQDN in our infrastructure
+                # the node key is compared against the hypervisor host grain
+                # this expects every hypervisor host name to exist only once across all domains
                 if '.' in node:
-                    hostpillar['node'] = node
+                    hostpillar['node'] = node.split('.', 1)[0]
                 else:
-                    hostpillar['node'] = f'{node}.{domain}'
+                    hostpillar['node'] = node
 
             hostinterfaces = hostconfig.get('interfaces', {})
 


### PR DESCRIPTION
This solves a situation where subdomained VMs are to be deployed on standalone hypervisors.

On clustered hypervisors, the VM foo.dev.example.com was able to be deployed on the hypervisor bar.example.com, because the VM is not equipped with a "node" key.
On standalone hypervisors, the same was not possible, as there the VM is equipped with a "node" key, which, if present, got the VM domain appended, causing the logic to skip VMs due to the VM domain not matching the hypervisor domain.

This solution has the drawback of (probably) breaking the sharing of hostnames with hypervisors across different domains. But, we do not use such practice anyways.