### PR TITLE
Use raw strings for susejunos regexes

### DIFF
--- a/juniper_junos-formula/_modules/susejunos.py
+++ b/juniper_junos-formula/_modules/susejunos.py
@@ -46,10 +46,10 @@ from salt.utils.napalm import proxy_napalm_wrap
 
 # ----------------------------------------------------------------------------------------------------------------------
 # module properties
-ifname_regex = re.compile('set interfaces (\S+)\s+')
-unit_regex = re.compile('set interfaces \S+\s+unit\s+(\S+)')
-vlanid_regex = re.compile('set vlans (\S+)\s+vlan-id\s+(\d+)')
-vlan_regex = re.compile('set vlans (\S+)')
+ifname_regex = re.compile(r'set interfaces (\S+)\s+')
+unit_regex = re.compile(r'set interfaces \S+\s+unit\s+(\S+)')
+vlanid_regex = re.compile(r'set vlans (\S+)\s+vlan-id\s+(\d+)')
+vlan_regex = re.compile(r'set vlans (\S+)')
 
 # ----------------------------------------------------------------------------------------------------------------------
 __virtualname__ = 'susejunos'


### PR DESCRIPTION
## Summary
- mark the four Junos configuration regexes as raw strings
- avoid invalid-escape SyntaxWarnings on modern Python without changing matching behavior

Fixes #278

## Validation
- Not run locally